### PR TITLE
Kd regression

### DIFF
--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -6,7 +6,7 @@ from IPython.display import display
 class CounterfactualExamples:
     """A class to store and visualize the resulting counterfactual explanations."""
 
-    def __init__(self, data_interface, test_instance, test_pred, final_cfs, final_cfs_preds, final_cfs_sparse=None, cfs_preds_sparse=None, posthoc_sparsity_param=0, desired_class="opposite", encoding='one-hot'):
+    def __init__(self, data_interface, test_instance, test_pred, final_cfs, final_cfs_preds, final_cfs_sparse=None, cfs_preds_sparse=None, posthoc_sparsity_param=0, desired_range=None, desired_class="opposite", encoding='one-hot', model_type='classifier'):
 
         self.data_interface = data_interface
         self.test_instance = test_instance
@@ -18,10 +18,15 @@ class CounterfactualExamples:
         self.final_cfs_df = None
         self.final_cfs_list = None
         self.posthoc_sparsity_param = posthoc_sparsity_param # might be useful for future additions
-        if desired_class == "opposite":
-            self.new_outcome = 1.0 - round(self.test_pred)
-        else:
-            self.new_outcome = desired_class
+
+        if model_type == 'classifier':
+            if desired_class == "opposite":
+                self.new_outcome = 1.0 - round(self.test_pred)
+            else:
+                self.new_outcome = desired_class
+        elif model_type == 'regressor':
+            self.new_outcome = desired_range
+
         self.encoding = encoding
         self.convert_to_dataframe() # transforming the test input from numpy to pandas dataframe
         if self.final_cfs_sparse is not None:
@@ -111,38 +116,37 @@ class CounterfactualExamples:
             self.final_cfs_list_sparse = self.final_cfs_df_sparse.values.tolist()
 
     def visualize_as_dataframe(self, display_sparse_df=True, show_only_changes=False):
-
         # original instance
         print('Query instance (original outcome : %i)' %round(self.test_pred))
-        display(self.org_instance) #  works only in Jupyter notebook
+        display(self.org_instance)  # works only in Jupyter notebook
         if len(self.final_cfs) > 0:
             if self.posthoc_sparsity_param == None:
-                print('\nCounterfactual set (new outcome : %i)' %(self.new_outcome))
+                print('\nCounterfactual set (new outcome: ', self.new_outcome)
                 self.display_df(self.final_cfs_df, show_only_changes)
 
             elif 'data_df' in self.data_interface.__dict__ and display_sparse_df==True and self.final_cfs_sparse is not None:
                 # CFs
-                print('\nDiverse Counterfactual set (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set (new outcome: ', self.new_outcome)
                 self.display_df(self.final_cfs_df_sparse, show_only_changes)
 
             elif 'data_df' in self.data_interface.__dict__ and display_sparse_df==True and self.final_cfs_sparse is None:
-                print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. displaying Diverse Counterfactual set without sparsity correction (new outcome : %i)' %(self.new_outcome))
+                print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. displaying Diverse Counterfactual set without sparsity correction (new outcome: ', self.new_outcome)
                 self.display_df(self.final_cfs_df, show_only_changes)
 
             elif 'data_df' not in self.data_interface.__dict__: # for private data
-                print('\nDiverse Counterfactual set without sparsity correction since only metadata about each feature is available (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set without sparsity correction since only metadata about each feature is available (new outcome: ', self.new_outcome)
                 self.display_df(self.final_cfs_df, show_only_changes)
 
             else:
                 # CFs
-                print('\nDiverse Counterfactual set without sparsity correction (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set without sparsity correction (new outcome: ', self.new_outcome)
                 self.display_df(self.final_cfs_df, show_only_changes)
         else:
             print('\n0 counterfactuals found!')
 
     def display_df(self, df, show_only_changes):
         if show_only_changes is False:
-            display(df)  #  works only in Jupyter notebook
+            display(df)  # works only in Jupyter notebook
         else:
             newdf = df.values.tolist()
             org = self.org_instance.values.tolist()[0]
@@ -152,7 +156,7 @@ class CounterfactualExamples:
                         newdf[ix][jx] = '-'
                     else:
                         newdf[ix][jx] = str(newdf[ix][jx])
-            display(pd.DataFrame(newdf, columns=df.columns)) #  works only in Jupyter notebook
+            display(pd.DataFrame(newdf, columns=df.columns))  # works only in Jupyter notebook
 
     def visualize_as_list(self, display_sparse_df=True, show_only_changes=False):
         # original instance
@@ -161,25 +165,25 @@ class CounterfactualExamples:
 
         if len(self.final_cfs) > 0:
             if self.posthoc_sparsity_param == None:
-                print('\nCounterfactual set (new outcome : %i)' %(self.new_outcome))
+                print('\nCounterfactual set (new outcome: ', self.new_outcome, ')')
                 self.print_list(self.final_cfs_df, show_only_changes)
 
             elif 'data_df' in self.data_interface.__dict__ and display_sparse_df==True and self.final_cfs_sparse is not None:
                 # CFs
-                print('\nDiverse Counterfactual set (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set (new outcome: ', self.new_outcome, ')')
                 self.print_list(self.final_cfs_list_sparse, show_only_changes)
 
             elif 'data_df' in self.data_interface.__dict__ and display_sparse_df==True and self.final_cfs_sparse is None:
-                print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. displaying Diverse Counterfactual set without sparsity correction (new outcome : %i)' %(self.new_outcome))
+                print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. displaying Diverse Counterfactual set without sparsity correction (new outcome: ', self.new_outcome, ')')
                 self.print_list(self.final_cfs_list_sparse, show_only_changes)
 
             elif 'data_df' not in self.data_interface.__dict__: # for private data
-                print('\nDiverse Counterfactual set without sparsity correction since only metadata about each feature is available (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set without sparsity correction since only metadata about each feature is available (new outcome: ', self.new_outcome, ')')
                 self.print_list(self.final_cfs_list, show_only_changes)
 
             else:
                 # CFs
-                print('\nDiverse Counterfactual set without sparsity correction (new outcome : %i)' %(self.new_outcome))
+                print('\nDiverse Counterfactual set without sparsity correction (new outcome: ', self.new_outcome, ')')
                 self.print_list(self.final_cfs_list, show_only_changes)
         else:
             print('\n0 counterfactuals found!')

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -137,7 +137,7 @@ class DiceGenetic(ExplainerBase):
         self.do_loss_initializations(yloss_type, diversity_loss_type, feature_weights, encoding='label')
         self.update_hyperparameters(proximity_weight, diversity_weight, categorical_penalty)
 
-    def generate_counterfactuals(self, query_instance, total_CFs, desired_range = None, desired_class="opposite", proximity_weight=0.5,
+    def generate_counterfactuals(self, query_instance, total_CFs, desired_range=None, desired_class="opposite", proximity_weight=0.5,
                                  diversity_weight=1.0, categorical_penalty=0.1, algorithm="DiverseCF",
                                  features_to_vary="all", permitted_range=None, yloss_type="hinge_loss",
                                  diversity_loss_type="dpp_style:inverse_dist", feature_weights="inverse_mad", stopping_threshold=0.5, posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="binary", verbose=True):
@@ -200,7 +200,18 @@ class DiceGenetic(ExplainerBase):
         self.do_param_initializations(total_CFs, desired_range, desired_class, query_instance, algorithm, features_to_vary, yloss_type, diversity_loss_type, feature_weights, proximity_weight, diversity_weight, categorical_penalty, verbose)
 
         query_instance = self.find_counterfactuals(query_instance, desired_range, desired_class, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm, verbose)
-        return exp.CounterfactualExamples(self.data_interface, query_instance, test_pred, self.final_cfs, self.cfs_preds, self.final_cfs_sparse, self.cfs_preds_sparse, posthoc_sparsity_param, desired_class, encoding='label')
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=query_instance,
+                                          test_pred=test_pred,
+                                          final_cfs=self.final_cfs,
+                                          final_cfs_preds=self.cfs_preds,
+                                          final_cfs_sparse=self.final_cfs_sparse,
+                                          cfs_preds_sparse=self.cfs_preds_sparse,
+                                          posthoc_sparsity_param=posthoc_sparsity_param,
+                                          desired_range=desired_range,
+                                          desired_class=desired_class,
+                                          encoding='label',
+                                          model_type=self.model.model_type)
 
     def predict_proba_fn(self, input_instance):
         """returns prediction probabilities"""

--- a/dice_ml/explainer_interfaces/dice_pytorch.py
+++ b/dice_ml/explainer_interfaces/dice_pytorch.py
@@ -109,9 +109,15 @@ class DicePyTorch(ExplainerBase):
             self.update_hyperparameters(proximity_weight, diversity_weight, categorical_penalty)
 
         query_instance, test_pred = self.find_counterfactuals(query_instance, desired_class, optimizer, learning_rate, min_iter, max_iter, project_iter, loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance, tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
-
-        return exp.CounterfactualExamples(self.data_interface, query_instance,
-        test_pred, self.final_cfs, self.cfs_preds, self.final_cfs_sparse, self.cfs_preds_sparse, posthoc_sparsity_param, desired_class)
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=query_instance,
+                                          test_pred=test_pred,
+                                          final_cfs=self.final_cfs,
+                                          final_cfs_preds=self.cfs_preds,
+                                          final_cfs_sparse=self.final_cfs_sparse,
+                                          cfs_preds_sparse=self.cfs_preds_sparse,
+                                          posthoc_sparsity_param=posthoc_sparsity_param,
+                                          desired_class=desired_class)
 
     def get_model_output(self, input_instance):
         """get output probability of ML model"""

--- a/dice_ml/explainer_interfaces/dice_tensorflow1.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow1.py
@@ -125,8 +125,15 @@ class DiceTensorFlow1(ExplainerBase):
 
         query_instance, test_pred = self.find_counterfactuals(query_instance, desired_class, learning_rate, min_iter, max_iter, project_iter, loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance, tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
-        return exp.CounterfactualExamples(self.data_interface, query_instance,
-        test_pred, self.final_cfs, self.cfs_preds, self.final_cfs_sparse, self.cfs_preds_sparse, posthoc_sparsity_param, desired_class)
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=query_instance,
+                                          test_pred=test_pred,
+                                          final_cfs=self.final_cfs,
+                                          final_cfs_preds=self.cfs_preds,
+                                          final_cfs_sparse=self.final_cfs_sparse,
+                                          cfs_preds_sparse=self.cfs_preds_sparse,
+                                          posthoc_sparsity_param=posthoc_sparsity_param,
+                                          desired_class=desired_class)
 
     def do_cf_initializations(self, total_CFs, algorithm, features_to_vary):
         """Intializes TF variables required for CF generation."""

--- a/dice_ml/explainer_interfaces/dice_tensorflow2.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow2.py
@@ -106,8 +106,15 @@ class DiceTensorFlow2(ExplainerBase):
 
         query_instance, test_pred = self.find_counterfactuals(query_instance, desired_class, optimizer, learning_rate, min_iter, max_iter, project_iter, loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance, tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
-        return exp.CounterfactualExamples(self.data_interface, query_instance,
-        test_pred, self.final_cfs, self.cfs_preds, self.final_cfs_sparse, self.cfs_preds_sparse, posthoc_sparsity_param, desired_class)
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=query_instance,
+                                          test_pred=test_pred,
+                                          final_cfs=self.final_cfs,
+                                          final_cfs_preds=self.cfs_preds,
+                                          final_cfs_sparse=self.final_cfs_sparse,
+                                          cfs_preds_sparse=self.cfs_preds_sparse,
+                                          posthoc_sparsity_param=posthoc_sparsity_param,
+                                          desired_class=desired_class)
 
     def predict_fn(self, input_instance):
         """prediction function"""

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -156,8 +156,15 @@ class ExplainerBase:
         else:
             print('Only %d (required %d) Diverse Counterfactuals found for the given configuation, perhaps try with different values of proximity (or diversity) weights or learning rate...' % (self.total_cfs_found, self.total_CFs), '; total time taken: %02d' % m, 'min %02d' % s, 'sec')
 
-        return exp.CounterfactualExamples(self.data_interface, query_instance,
-        test_pred, self.final_cfs, self.cfs_preds, self.final_cfs_sparse, self.cfs_preds_sparse, posthoc_sparsity_param, desired_class)
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=query_instance,
+                                          test_pred=test_pred,
+                                          final_cfs=self.final_cfs,
+                                          final_cfs_preds=self.cfs_preds,
+                                          final_cfs_sparse=self.final_cfs_sparse,
+                                          cfs_preds_sparse=self.cfs_preds_sparse,
+                                          posthoc_sparsity_param=posthoc_sparsity_param,
+                                          desired_class=desired_class)
 
     def local_feature_importance(self, cf_object):
         org_instance = cf_object.org_instance
@@ -399,10 +406,18 @@ class ExplainerBase:
                 if current_val == right or current_val == left:
                     break
 
-                if(((self.target_cf_class == 0 and current_pred < self.stopping_threshold) or (self.target_cf_class == 1 and current_pred > self.stopping_threshold))):
-                    left = current_val + (10**-decimal_prec[feat_ix])
-                else:
-                    right = current_val - (10**-decimal_prec[feat_ix])
+                if self.model.model_type == 'classifier':
+                    if (((self.target_cf_class == 0 and current_pred < self.stopping_threshold) or (
+                            self.target_cf_class == 1 and current_pred > self.stopping_threshold))):
+                        left = current_val + (10 ** -decimal_prec[feat_ix])
+                    else:
+                        right = current_val - (10 ** -decimal_prec[feat_ix])
+
+                elif self.model.model_type == 'regressor':
+                    if self.target_cf_range[0] <= current_pred <= self.target_cf_range[1]:
+                        left = current_val + (10 ** -decimal_prec[feat_ix])
+                    else:
+                        right = current_val - (10 ** -decimal_prec[feat_ix])
 
         else:
             left = query_instance.ravel()[feat_ix]

--- a/dice_ml/explainer_interfaces/feasible_base_vae.py
+++ b/dice_ml/explainer_interfaces/feasible_base_vae.py
@@ -227,4 +227,9 @@ class FeasibleBaseVAE(ExplainerBase):
         result['CF-Pred']= final_cf_pred[0]
         
         # Adding empty list for sparse cf gen and pred; adding 'NA' for the posthoc sparsity cofficient
-        return exp.CounterfactualExamples(self.data_interface, result['query-instance'], result['test-pred'], result['CF'], result['CF-Pred'],  posthoc_sparsity_param=None)
+        return exp.CounterfactualExamples(data_interface=self.data_interface,
+                                          test_instance=result['query-instance'],
+                                          test_pred=result['test-pred'],
+                                          final_cfs=result['CF'],
+                                          final_cfs_preds=result['CF-Pred'],
+                                          posthoc_sparsity_param=None)


### PR DESCRIPTION
- Added `desired_range` and `model_type` in diverse_counterfactuals.py to print the correct statements. Also corrected the print statements to print the desired range as the outcome in regression problems
- Added predicted outcome to a copy of the dataframe (earlier it was adding it directly to the original dataframe)
- dice_KD now builds KD trees within generate counterfactuals (when a user supplies desired_range or desired_class)
- Handled the case when there are no instances within desired_range in the training data (KD tree is empty)