### PR TITLE
Move tensorflow and pytorch to optional dependencies

### DIFF
--- a/requirements-deeplearning.txt
+++ b/requirements-deeplearning.txt
@@ -1,0 +1,3 @@
+tensorflow>=1.13.0-rc1 
+torch
+torchvision

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 numpy # if you are using tensorflow 1.x, it requires numpy<=1.16 
 pandas
 scikit-learn
-tensorflow>=1.13.0-rc1 
-torch
-torchvision
 h5py

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,14 @@ with open("README.rst", "r") as fh:
 with open('requirements.txt', encoding='utf-8') as f:
     install_requires = f.read().splitlines()
 
+# Deep learning packages are optional to install
+extras = ["deeplearning"]
+extras_require = dict()
+for e in extras:
+    req_file = "requirements-{0}.txt".format(e)
+    with open(req_file) as f:
+        extras_require[e] = [line.strip() for line in f]
+
 setuptools.setup(
     name="dice_ml",
     version="0.4",
@@ -27,6 +35,7 @@ setuptools.setup(
     ],
     keywords='machine-learning explanation interpretability counterfactual',
     install_requires=install_requires,
+    extras_require=extras_require,
     include_package_data=True,
     package_data={
         # If any package contains *.h5 files, include them:


### PR DESCRIPTION
These are quite big packages and may not be needed if the user needs to explain sklearn models. 

If needed, they can installed as optional dependencies using pip, `pip install dice-ml[deeplearning]`