### PR TITLE
Move Iris dataset to as_frame in DiCE_multiclass_classification_and_regression.ipynb

### DIFF
--- a/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
+++ b/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
@@ -12,18 +12,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -31,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +149,7 @@
        "4       0  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -171,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -187,9 +178,9 @@
       " 1   sepal width (cm)   150 non-null    float64\n",
       " 2   petal length (cm)  150 non-null    float64\n",
       " 3   petal width (cm)   150 non-null    float64\n",
-      " 4   target             150 non-null    int32  \n",
-      "dtypes: float64(4), int32(1)\n",
-      "memory usage: 5.4 KB\n"
+      " 4   target             150 non-null    int64  \n",
+      "dtypes: float64(4), int64(1)\n",
+      "memory usage: 6.0 KB\n"
      ]
     }
    ],
@@ -199,17 +190,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
+    "outcome_name = \"target\"\n",
     "continuous_features_iris = df_iris.drop(outcome_name, axis=1).columns.tolist()\n",
     "target = df_iris[outcome_name]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,14 +270,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:24<00:00, 24.43s/it]"
+      "100%|██████████| 1/1 [00:10<00:00, 10.28s/it]"
      ]
     },
     {
@@ -393,18 +385,26 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>6.0</td>\n",
+       "      <td>4.3</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.8</td>\n",
+       "      <td>4.9</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>6.2</td>\n",
+       "      <td>4.3</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2.3</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.6</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.9</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -415,17 +415,39 @@
        "      <td>1.8</td>\n",
        "      <td>2</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.9</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>6.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "   sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
-       "0                6.0               3.0                1.0               1.8   \n",
-       "0                6.2               3.0                1.0               2.3   \n",
+       "0                4.3               3.0                4.9               2.0   \n",
+       "0                4.3               3.0                5.0               2.0   \n",
+       "0                5.6               3.0                4.9               2.0   \n",
        "0                6.0               3.0                4.8               1.8   \n",
+       "0                5.9               3.0                5.1               1.8   \n",
+       "0                6.0               3.0                5.1               1.8   \n",
        "\n",
        "   target  \n",
+       "0       2  \n",
+       "0       2  \n",
+       "0       2  \n",
        "0       2  \n",
        "0       2  \n",
        "0       2  "
@@ -444,14 +466,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.78it/s]"
+      "100%|██████████| 2/2 [00:00<00:00,  3.90it/s]"
      ]
     },
     {
@@ -559,14 +581,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>-</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>4.9</td>\n",
-       "      <td>1.8</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
        "      <td>6.3</td>\n",
        "      <td>2.8</td>\n",
        "      <td>5.1</td>\n",
@@ -574,7 +588,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>1</th>\n",
        "      <td>6.0</td>\n",
        "      <td>3.0</td>\n",
        "      <td>4.8</td>\n",
@@ -582,7 +596,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>2</th>\n",
        "      <td>5.9</td>\n",
        "      <td>3.0</td>\n",
        "      <td>5.1</td>\n",
@@ -590,7 +604,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>3</th>\n",
        "      <td>6.1</td>\n",
        "      <td>3.0</td>\n",
        "      <td>4.9</td>\n",
@@ -598,7 +612,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>4</th>\n",
        "      <td>5.6</td>\n",
        "      <td>2.8</td>\n",
        "      <td>4.9</td>\n",
@@ -606,10 +620,18 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
+       "      <th>5</th>\n",
        "      <td>6.2</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>2.8</td>\n",
        "      <td>4.8</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6.3</td>\n",
+       "      <td>-</td>\n",
+       "      <td>5.6</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
@@ -619,13 +641,13 @@
       ],
       "text/plain": [
        "  sepal length (cm) sepal width (cm) petal length (cm) petal width (cm) target\n",
-       "0                 -              3.0               4.9              1.8    2.0\n",
-       "1               6.3              2.8               5.1              1.5    2.0\n",
-       "2               6.0              3.0               4.8              1.8    2.0\n",
-       "3               5.9              3.0               5.1              1.8    2.0\n",
-       "4               6.1              3.0               4.9              1.8    2.0\n",
-       "5               5.6              2.8               4.9              2.0    2.0\n",
-       "6               6.2              3.0               4.8              1.8    2.0"
+       "0               6.3              2.8               5.1              1.5    2.0\n",
+       "1               6.0              3.0               4.8              1.8    2.0\n",
+       "2               5.9              3.0               5.1              1.8    2.0\n",
+       "3               6.1              3.0               4.9              1.8    2.0\n",
+       "4               5.6              2.8               4.9              2.0    2.0\n",
+       "5               6.2              2.8               4.8              1.8    2.0\n",
+       "6               6.3                -               5.6              1.8    2.0"
       ]
      },
      "metadata": {},
@@ -745,14 +767,6 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>6.2</td>\n",
-       "      <td>3.4</td>\n",
-       "      <td>4.9</td>\n",
-       "      <td>2.3</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
        "      <td>6.1</td>\n",
        "      <td>3.0</td>\n",
        "      <td>4.9</td>\n",
@@ -760,7 +774,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>3</th>\n",
        "      <td>6.0</td>\n",
        "      <td>3.0</td>\n",
        "      <td>4.8</td>\n",
@@ -768,7 +782,7 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
+       "      <th>4</th>\n",
        "      <td>6.4</td>\n",
        "      <td>3.2</td>\n",
        "      <td>5.3</td>\n",
@@ -776,11 +790,19 @@
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
+       "      <th>5</th>\n",
        "      <td>6.2</td>\n",
        "      <td>3.4</td>\n",
        "      <td>5.4</td>\n",
        "      <td>2.3</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -791,11 +813,11 @@
        "  sepal length (cm) sepal width (cm) petal length (cm) petal width (cm) target\n",
        "0               6.5              3.2               5.1              2.0    2.0\n",
        "1               6.4              3.1               5.5              1.8    2.0\n",
-       "2               6.2              3.4               4.9              2.3    2.0\n",
-       "3               6.1              3.0               4.9              1.8    2.0\n",
-       "4               6.0              3.0               4.8              1.8    2.0\n",
-       "5               6.4              3.2               5.3              2.3    2.0\n",
-       "6               6.2              3.4               5.4              2.3    2.0"
+       "2               6.1              3.0               4.9              1.8    2.0\n",
+       "3               6.0              3.0               4.8              1.8    2.0\n",
+       "4               6.4              3.2               5.3              2.3    2.0\n",
+       "5               6.2              3.4               5.4              2.3    2.0\n",
+       "6               6.5              3.0               5.5              1.8    2.0"
       ]
      },
      "metadata": {},
@@ -825,7 +847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -971,7 +993,7 @@
        "4     18.7  396.90   5.33    36.2  "
       ]
      },
-     "execution_count": 36,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -986,7 +1008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1023,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1033,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1070,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1081,7 +1103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,16 +1119,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|                                                                                            | 0/1 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      "  0%|          | 0/1 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
       "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.20it/s]"
+      "100%|██████████| 1/1 [00:00<00:00,  4.71it/s]"
      ]
     },
     {
@@ -1176,7 +1198,7 @@
        "      <td>16.6</td>\n",
        "      <td>391.25</td>\n",
        "      <td>11.38</td>\n",
-       "      <td>23.971</td>\n",
+       "      <td>24.055</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1187,7 +1209,7 @@
        "0  0.11329  30.0   4.93   0.0  0.428  6.897  54.3  6.3361  6.0  300.0   \n",
        "\n",
        "   PTRATIO       B  LSTAT  target  \n",
-       "0     16.6  391.25  11.38  23.971  "
+       "0     16.6  391.25  11.38  24.055  "
       ]
      },
      "metadata": {},
@@ -1254,37 +1276,37 @@
        "      <td>16.1</td>\n",
        "      <td>390.4</td>\n",
        "      <td>4.86</td>\n",
-       "      <td>32.94899999999999</td>\n",
+       "      <td>33.70500000000001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.08221</td>\n",
-       "      <td>22.0</td>\n",
-       "      <td>5.9</td>\n",
+       "      <td>0.1</td>\n",
+       "      <td>34.0</td>\n",
+       "      <td>2.9</td>\n",
        "      <td>-</td>\n",
-       "      <td>0.431</td>\n",
-       "      <td>6.957</td>\n",
-       "      <td>6.8</td>\n",
-       "      <td>8.9067</td>\n",
+       "      <td>0.433</td>\n",
+       "      <td>6.982</td>\n",
+       "      <td>17.7</td>\n",
+       "      <td>3.4952</td>\n",
        "      <td>7.0</td>\n",
-       "      <td>330.0</td>\n",
-       "      <td>19.1</td>\n",
-       "      <td>386.1</td>\n",
-       "      <td>3.53</td>\n",
-       "      <td>30.95299999999997</td>\n",
+       "      <td>329.0</td>\n",
+       "      <td>16.1</td>\n",
+       "      <td>390.4</td>\n",
+       "      <td>1.73</td>\n",
+       "      <td>34.558000000000014</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
-       "0      0.1  34.0   6.1    -  0.433  6.982  17.7  5.4917  7.0  329.0    16.1   \n",
-       "1  0.08221  22.0   5.9    -  0.431  6.957   6.8  8.9067  7.0  330.0    19.1   \n",
+       "  CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
+       "0  0.1  34.0   6.1    -  0.433  6.982  17.7  5.4917  7.0  329.0    16.1   \n",
+       "1  0.1  34.0   2.9    -  0.433  6.982  17.7  3.4952  7.0  329.0    16.1   \n",
        "\n",
-       "       B LSTAT             target  \n",
-       "0  390.4  4.86  32.94899999999999  \n",
-       "1  386.1  3.53  30.95299999999997  "
+       "       B LSTAT              target  \n",
+       "0  390.4  4.86   33.70500000000001  \n",
+       "1  390.4  1.73  34.558000000000014  "
       ]
      },
      "metadata": {},
@@ -1302,18 +1324,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|                                                                                            | 0/2 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      "  0%|          | 0/2 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
       "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
-      " 50%|██████████████████████████████████████████                                          | 1/2 [00:00<00:00,  2.90it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      " 50%|█████     | 1/2 [00:00<00:00,  4.41it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
       "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  2.75it/s]"
+      "100%|██████████| 2/2 [00:00<00:00,  4.33it/s]"
      ]
     },
     {
@@ -1383,7 +1405,7 @@
        "      <td>13.6</td>\n",
        "      <td>395.52</td>\n",
        "      <td>3.16</td>\n",
-       "      <td>49.062</td>\n",
+       "      <td>48.64</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1394,7 +1416,7 @@
        "0  0.01501  90.0   1.21   1.0  0.401  7.923  24.8  5.885  1.0  198.0     13.6   \n",
        "\n",
        "        B  LSTAT  target  \n",
-       "0  395.52   3.16  49.062  "
+       "0  395.52   3.16   48.64  "
       ]
      },
      "metadata": {},
@@ -1465,71 +1487,71 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
+       "      <td>0.00632</td>\n",
        "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>2.5</td>\n",
+       "      <td>1.2</td>\n",
        "      <td>0.0</td>\n",
        "      <td>-</td>\n",
-       "      <td>7.61</td>\n",
-       "      <td>83.3</td>\n",
-       "      <td>2.741</td>\n",
        "      <td>-</td>\n",
        "      <td>-</td>\n",
+       "      <td>5.6484</td>\n",
        "      <td>-</td>\n",
-       "      <td>395.6</td>\n",
-       "      <td>-</td>\n",
-       "      <td>44.443000000000026</td>\n",
+       "      <td>255.0</td>\n",
+       "      <td>14.4</td>\n",
+       "      <td>395.5</td>\n",
+       "      <td>1.73</td>\n",
+       "      <td>48.319</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>-</td>\n",
-       "      <td>80.0</td>\n",
-       "      <td>0.5</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>-</td>\n",
+       "      <td>0.00632</td>\n",
        "      <td>-</td>\n",
        "      <td>2.9</td>\n",
-       "      <td>1.1296</td>\n",
-       "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>394.2</td>\n",
-       "      <td>1.73</td>\n",
-       "      <td>48.43299999999999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>0.5</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.385</td>\n",
        "      <td>-</td>\n",
        "      <td>-</td>\n",
+       "      <td>2.741</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>-</td>\n",
+       "      <td>12.6</td>\n",
+       "      <td>395.5</td>\n",
+       "      <td>1.73</td>\n",
+       "      <td>48.471000000000004</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.00632</td>\n",
+       "      <td>-</td>\n",
+       "      <td>2.7</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.416</td>\n",
+       "      <td>8.034</td>\n",
+       "      <td>31.9</td>\n",
+       "      <td>6.3361</td>\n",
        "      <td>-</td>\n",
        "      <td>244.0</td>\n",
-       "      <td>15.9</td>\n",
-       "      <td>395.5</td>\n",
-       "      <td>-</td>\n",
-       "      <td>47.11500000000001</td>\n",
+       "      <td>14.7</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>3.11</td>\n",
+       "      <td>48.63</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  CRIM    ZN INDUS CHAS    NOX    RM   AGE     DIS RAD    TAX PTRATIO      B  \\\n",
-       "0    -     -   1.2    -      -     -     -       -   -      -       -  395.5   \n",
-       "1    -     -   2.5  0.0      -  7.61  83.3   2.741   -      -       -  395.6   \n",
-       "2    -  80.0   0.5  0.0      -     -   2.9  1.1296   -      -       -  394.2   \n",
-       "3    -     -   0.5  0.0  0.385     -     -       -   -  244.0    15.9  395.5   \n",
+       "      CRIM ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
+       "0        -  -   1.2    -      -      -     -       -    -      -       -   \n",
+       "1  0.00632  -   1.2  0.0      -      -     -  5.6484    -  255.0    14.4   \n",
+       "2  0.00632  -   2.9  0.0  0.385      -     -   2.741  2.0      -    12.6   \n",
+       "3  0.00632  -   2.7  0.0  0.416  8.034  31.9  6.3361    -  244.0    14.7   \n",
        "\n",
-       "  LSTAT              target  \n",
-       "0     -                   -  \n",
-       "1     -  44.443000000000026  \n",
-       "2  1.73   48.43299999999999  \n",
-       "3     -   47.11500000000001  "
+       "       B LSTAT              target  \n",
+       "0  395.5     -                   -  \n",
+       "1  395.5  1.73              48.319  \n",
+       "2  395.5  1.73  48.471000000000004  \n",
+       "3    0.3  3.11               48.63  "
       ]
      },
      "metadata": {},
@@ -1595,7 +1617,7 @@
        "      <td>15.2</td>\n",
        "      <td>389.71</td>\n",
        "      <td>4.69</td>\n",
-       "      <td>30.25</td>\n",
+       "      <td>29.99</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1606,7 +1628,7 @@
        "0  0.06911  45.0   3.44   0.0  0.437  6.739  30.8  6.4798  5.0  398.0   \n",
        "\n",
        "   PTRATIO       B  LSTAT  target  \n",
-       "0     15.2  389.71   4.69   30.25  "
+       "0     15.2  389.71   4.69   29.99  "
       ]
      },
      "metadata": {},
@@ -1661,23 +1683,23 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0.03578</td>\n",
-       "      <td>20.0</td>\n",
-       "      <td>3.3</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.5</td>\n",
        "      <td>-</td>\n",
        "      <td>0.443</td>\n",
-       "      <td>7.82</td>\n",
-       "      <td>64.5</td>\n",
-       "      <td>4.6947</td>\n",
+       "      <td>7.454</td>\n",
+       "      <td>34.2</td>\n",
+       "      <td>6.3361</td>\n",
        "      <td>-</td>\n",
-       "      <td>216.0</td>\n",
-       "      <td>14.9</td>\n",
-       "      <td>387.3</td>\n",
-       "      <td>3.76</td>\n",
-       "      <td>45.901</td>\n",
+       "      <td>244.0</td>\n",
+       "      <td>15.9</td>\n",
+       "      <td>386.3</td>\n",
+       "      <td>3.11</td>\n",
+       "      <td>42.248000000000026</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.00632</td>\n",
+       "      <td>0.03578</td>\n",
        "      <td>20.0</td>\n",
        "      <td>3.3</td>\n",
        "      <td>-</td>\n",
@@ -1690,58 +1712,58 @@
        "      <td>14.9</td>\n",
        "      <td>387.3</td>\n",
        "      <td>3.76</td>\n",
-       "      <td>46.003</td>\n",
+       "      <td>45.72200000000001</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.00632</td>\n",
-       "      <td>20.0</td>\n",
+       "      <td>0.01381</td>\n",
+       "      <td>80.0</td>\n",
        "      <td>0.5</td>\n",
        "      <td>-</td>\n",
        "      <td>0.422</td>\n",
        "      <td>7.875</td>\n",
        "      <td>32.0</td>\n",
-       "      <td>4.6947</td>\n",
-       "      <td>-</td>\n",
-       "      <td>216.0</td>\n",
-       "      <td>14.9</td>\n",
-       "      <td>387.3</td>\n",
-       "      <td>1.73</td>\n",
-       "      <td>48.361999999999995</td>\n",
+       "      <td>5.6484</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>255.0</td>\n",
+       "      <td>14.4</td>\n",
+       "      <td>394.2</td>\n",
+       "      <td>2.97</td>\n",
+       "      <td>49.246</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.00632</td>\n",
-       "      <td>20.0</td>\n",
-       "      <td>0.5</td>\n",
+       "      <td>0.02177</td>\n",
+       "      <td>82.5</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>-</td>\n",
-       "      <td>0.422</td>\n",
-       "      <td>7.875</td>\n",
-       "      <td>2.9</td>\n",
-       "      <td>1.1296</td>\n",
-       "      <td>-</td>\n",
-       "      <td>187.0</td>\n",
+       "      <td>0.415</td>\n",
+       "      <td>7.61</td>\n",
+       "      <td>15.7</td>\n",
+       "      <td>6.27</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>348.0</td>\n",
        "      <td>14.7</td>\n",
-       "      <td>396.9</td>\n",
-       "      <td>3.01</td>\n",
-       "      <td>48.59300000000001</td>\n",
+       "      <td>395.4</td>\n",
+       "      <td>3.11</td>\n",
+       "      <td>43.20900000000005</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS RAD    TAX PTRATIO  \\\n",
-       "0  0.03578  20.0   3.3    -  0.443   7.82  64.5  4.6947   -  216.0    14.9   \n",
-       "1  0.00632  20.0   3.3    -  0.443   7.82  64.5  4.6947   -  216.0    14.9   \n",
-       "2  0.00632  20.0   0.5    -  0.422  7.875  32.0  4.6947   -  216.0    14.9   \n",
-       "3  0.00632  20.0   0.5    -  0.422  7.875   2.9  1.1296   -  187.0    14.7   \n",
+       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
+       "0  0.03578   0.0   0.5    -  0.443  7.454  34.2  6.3361    -  244.0    15.9   \n",
+       "1  0.03578  20.0   3.3    -  0.443   7.82  64.5  4.6947    -  216.0    14.9   \n",
+       "2  0.01381  80.0   0.5    -  0.422  7.875  32.0  5.6484  4.0  255.0    14.4   \n",
+       "3  0.02177  82.5   2.0    -  0.415   7.61  15.7    6.27  2.0  348.0    14.7   \n",
        "\n",
        "       B LSTAT              target  \n",
-       "0  387.3  3.76              45.901  \n",
-       "1  387.3  3.76              46.003  \n",
-       "2  387.3  1.73  48.361999999999995  \n",
-       "3  396.9  3.01   48.59300000000001  "
+       "0  386.3  3.11  42.248000000000026  \n",
+       "1  387.3  3.76   45.72200000000001  \n",
+       "2  394.2  2.97              49.246  \n",
+       "3  395.4  3.11   43.20900000000005  "
       ]
      },
      "metadata": {},
@@ -1758,9 +1780,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:env1] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-env1-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1772,7 +1794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
+++ b/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
@@ -12,9 +12,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
@@ -22,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,20 +51,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "outcome_name = 'target'\n",
-    "# Function to process sklearn's internal datasets\n",
-    "def sklearn_to_df(sklearn_dataset):\n",
-    "    df = pd.DataFrame(sklearn_dataset.data, columns=sklearn_dataset.feature_names)\n",
-    "    df[outcome_name] = pd.Series(sklearn_dataset.target)\n",
-    "    return df"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -71,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -163,20 +158,20 @@
        "4       0  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "from sklearn.datasets import load_iris\n",
-    "df_iris = sklearn_to_df(load_iris())\n",
+    "df_iris = load_iris(as_frame=True).frame\n",
     "df_iris.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -192,9 +187,9 @@
       " 1   sepal width (cm)   150 non-null    float64\n",
       " 2   petal length (cm)  150 non-null    float64\n",
       " 3   petal width (cm)   150 non-null    float64\n",
-      " 4   target             150 non-null    int64  \n",
-      "dtypes: float64(4), int64(1)\n",
-      "memory usage: 6.0 KB\n"
+      " 4   target             150 non-null    int32  \n",
+      "dtypes: float64(4), int32(1)\n",
+      "memory usage: 5.4 KB\n"
      ]
     }
    ],
@@ -204,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,14 +278,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:24<00:00, 24.43s/it]"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Query instance (original outcome : 0)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -350,7 +359,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Diverse Counterfactual set (new outcome: 2)\n"
+      "Diverse Counterfactual set (new outcome: 2.0)\n"
      ]
     },
     {
@@ -384,59 +393,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>4.3</td>\n",
-       "      <td>3.3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>4.3</td>\n",
+       "      <td>6.0</td>\n",
        "      <td>3.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.2</td>\n",
-       "      <td>0</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>4.3</td>\n",
-       "      <td>2.7</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4.3</td>\n",
-       "      <td>3.2</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>4.3</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>4.3</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>4.3</td>\n",
+       "      <th>0</th>\n",
+       "      <td>6.2</td>\n",
        "      <td>3.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.1</td>\n",
-       "      <td>0</td>\n",
+       "      <td>2.3</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>6.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.8</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -444,22 +421,14 @@
       ],
       "text/plain": [
        "   sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)  \\\n",
-       "0                4.3               3.3                1.0               0.1   \n",
-       "1                4.3               3.0                1.0               0.2   \n",
-       "2                4.3               2.7                1.0               0.1   \n",
-       "3                4.3               3.2                1.0               0.1   \n",
-       "4                4.3               2.0                1.0               0.1   \n",
-       "5                4.3               2.0                1.0               0.1   \n",
-       "6                4.3               3.0                1.0               0.1   \n",
+       "0                6.0               3.0                1.0               1.8   \n",
+       "0                6.2               3.0                1.0               2.3   \n",
+       "0                6.0               3.0                4.8               1.8   \n",
        "\n",
        "   target  \n",
-       "0       0  \n",
-       "1       0  \n",
-       "2       0  \n",
-       "3       0  \n",
-       "4       0  \n",
-       "5       0  \n",
-       "6       0  "
+       "0       2  \n",
+       "0       2  \n",
+       "0       2  "
       ]
      },
      "metadata": {},
@@ -475,14 +444,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.78it/s]"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Query instance (original outcome : 1)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -542,7 +525,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Diverse Counterfactual set (new outcome: 2)\n"
+      "Diverse Counterfactual set (new outcome: 2.0)\n"
      ]
     },
     {
@@ -576,57 +559,57 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>6.0</td>\n",
        "      <td>-</td>\n",
-       "      <td>4.8</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.9</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>6.2</td>\n",
-       "      <td>-</td>\n",
+       "      <td>6.3</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>6.0</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>4.8</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>6.1</td>\n",
-       "      <td>-</td>\n",
-       "      <td>4.9</td>\n",
-       "      <td>1.8</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>-</td>\n",
-       "      <td>-</td>\n",
-       "      <td>4.9</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>4.9</td>\n",
-       "      <td>2.5</td>\n",
-       "      <td>4.5</td>\n",
-       "      <td>1.7</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
        "      <td>5.9</td>\n",
-       "      <td>-</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>5.1</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>6.3</td>\n",
-       "      <td>2.7</td>\n",
+       "      <th>4</th>\n",
+       "      <td>6.1</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>4.9</td>\n",
+       "      <td>1.8</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5.6</td>\n",
+       "      <td>2.8</td>\n",
+       "      <td>4.9</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.8</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
@@ -636,13 +619,13 @@
       ],
       "text/plain": [
        "  sepal length (cm) sepal width (cm) petal length (cm) petal width (cm) target\n",
-       "0               6.0                -               4.8              1.8    2.0\n",
-       "1               6.2                -               4.8              1.8    2.0\n",
-       "2               6.1                -               4.9              1.8    2.0\n",
-       "3                 -                -               4.9              2.0    2.0\n",
-       "4               4.9              2.5               4.5              1.7    2.0\n",
-       "5               5.9                -               5.1              1.8    2.0\n",
-       "6               6.3              2.7               4.9              1.8    2.0"
+       "0                 -              3.0               4.9              1.8    2.0\n",
+       "1               6.3              2.8               5.1              1.5    2.0\n",
+       "2               6.0              3.0               4.8              1.8    2.0\n",
+       "3               5.9              3.0               5.1              1.8    2.0\n",
+       "4               6.1              3.0               4.9              1.8    2.0\n",
+       "5               5.6              2.8               4.9              2.0    2.0\n",
+       "6               6.2              3.0               4.8              1.8    2.0"
       ]
      },
      "metadata": {},
@@ -712,7 +695,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Diverse Counterfactual set (new outcome: 2)\n"
+      "Diverse Counterfactual set (new outcome: 2.0)\n"
      ]
     },
     {
@@ -746,58 +729,58 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>6.1</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>-</td>\n",
-       "      <td>1.8</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.1</td>\n",
+       "      <td>2.0</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>6.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>-</td>\n",
+       "      <td>6.4</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>5.5</td>\n",
        "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>-</td>\n",
-       "      <td>2.8</td>\n",
-       "      <td>-</td>\n",
-       "      <td>1.8</td>\n",
+       "      <td>6.2</td>\n",
+       "      <td>3.4</td>\n",
+       "      <td>4.9</td>\n",
+       "      <td>2.3</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>6.5</td>\n",
-       "      <td>-</td>\n",
-       "      <td>5.1</td>\n",
-       "      <td>2.0</td>\n",
+       "      <td>6.1</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.9</td>\n",
+       "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>-</td>\n",
-       "      <td>2.8</td>\n",
-       "      <td>5.1</td>\n",
-       "      <td>-</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4.8</td>\n",
+       "      <td>1.8</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>-</td>\n",
-       "      <td>2.7</td>\n",
-       "      <td>-</td>\n",
-       "      <td>1.8</td>\n",
+       "      <td>6.4</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>5.3</td>\n",
+       "      <td>2.3</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>5.9</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>5.1</td>\n",
-       "      <td>1.8</td>\n",
+       "      <td>6.2</td>\n",
+       "      <td>3.4</td>\n",
+       "      <td>5.4</td>\n",
+       "      <td>2.3</td>\n",
        "      <td>2.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -806,13 +789,13 @@
       ],
       "text/plain": [
        "  sepal length (cm) sepal width (cm) petal length (cm) petal width (cm) target\n",
-       "0               6.1              3.0                 -              1.8    2.0\n",
-       "1               6.0              3.0                 -              1.8    2.0\n",
-       "2                 -              2.8                 -              1.8    2.0\n",
-       "3               6.5                -               5.1              2.0    2.0\n",
-       "4                 -              2.8               5.1                -    2.0\n",
-       "5                 -              2.7                 -              1.8    2.0\n",
-       "6               5.9              3.0               5.1              1.8    2.0"
+       "0               6.5              3.2               5.1              2.0    2.0\n",
+       "1               6.4              3.1               5.5              1.8    2.0\n",
+       "2               6.2              3.4               4.9              2.3    2.0\n",
+       "3               6.1              3.0               4.9              1.8    2.0\n",
+       "4               6.0              3.0               4.8              1.8    2.0\n",
+       "5               6.4              3.2               5.3              2.3    2.0\n",
+       "6               6.2              3.4               5.4              2.3    2.0"
       ]
      },
      "metadata": {},
@@ -842,7 +825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -988,20 +971,22 @@
        "4     18.7  396.90   5.33    36.2  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "from sklearn.datasets import load_boston\n",
-    "df_boston = sklearn_to_df(load_boston())\n",
+    "boston_data = load_boston()\n",
+    "df_boston = pd.DataFrame(boston_data.data, columns=boston_data.feature_names)\n",
+    "df_boston[outcome_name] = pd.Series(boston_data.target)\n",
     "df_boston.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1038,7 +1023,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1085,7 +1070,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1096,7 +1081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1112,15 +1097,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
-      "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n"
+      "  0%|                                                                                            | 0/1 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
+      "100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.20it/s]"
      ]
     },
     {
@@ -1128,6 +1114,13 @@
      "output_type": "stream",
      "text": [
       "Query instance (original outcome : 24)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -1183,7 +1176,7 @@
        "      <td>16.6</td>\n",
        "      <td>391.25</td>\n",
        "      <td>11.38</td>\n",
-       "      <td>24.014</td>\n",
+       "      <td>23.971</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1194,7 +1187,7 @@
        "0  0.11329  30.0   4.93   0.0  0.428  6.897  54.3  6.3361  6.0  300.0   \n",
        "\n",
        "   PTRATIO       B  LSTAT  target  \n",
-       "0     16.6  391.25  11.38  24.014  "
+       "0     16.6  391.25  11.38  23.971  "
       ]
      },
      "metadata": {},
@@ -1248,37 +1241,37 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.01301</td>\n",
+       "      <td>0.1</td>\n",
        "      <td>34.0</td>\n",
        "      <td>6.1</td>\n",
        "      <td>-</td>\n",
-       "      <td>0.385</td>\n",
+       "      <td>0.433</td>\n",
        "      <td>6.982</td>\n",
-       "      <td>49.3</td>\n",
+       "      <td>17.7</td>\n",
        "      <td>5.4917</td>\n",
        "      <td>7.0</td>\n",
        "      <td>329.0</td>\n",
-       "      <td>15.5</td>\n",
+       "      <td>16.1</td>\n",
        "      <td>390.4</td>\n",
        "      <td>4.86</td>\n",
-       "      <td>33.047000885009766</td>\n",
+       "      <td>32.94899999999999</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.10469</td>\n",
-       "      <td>40.0</td>\n",
-       "      <td>6.2</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.447</td>\n",
-       "      <td>7.267</td>\n",
-       "      <td>49.0</td>\n",
-       "      <td>4.7872</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>254.0</td>\n",
-       "      <td>17.6</td>\n",
-       "      <td>389.2</td>\n",
-       "      <td>6.05</td>\n",
-       "      <td>33.95500183105469</td>\n",
+       "      <td>0.08221</td>\n",
+       "      <td>22.0</td>\n",
+       "      <td>5.9</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.431</td>\n",
+       "      <td>6.957</td>\n",
+       "      <td>6.8</td>\n",
+       "      <td>8.9067</td>\n",
+       "      <td>7.0</td>\n",
+       "      <td>330.0</td>\n",
+       "      <td>19.1</td>\n",
+       "      <td>386.1</td>\n",
+       "      <td>3.53</td>\n",
+       "      <td>30.95299999999997</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1286,12 +1279,12 @@
       ],
       "text/plain": [
        "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
-       "0  0.01301  34.0   6.1    -  0.385  6.982  49.3  5.4917  7.0  329.0    15.5   \n",
-       "1  0.10469  40.0   6.2  1.0  0.447  7.267  49.0  4.7872  4.0  254.0    17.6   \n",
+       "0      0.1  34.0   6.1    -  0.433  6.982  17.7  5.4917  7.0  329.0    16.1   \n",
+       "1  0.08221  22.0   5.9    -  0.431  6.957   6.8  8.9067  7.0  330.0    19.1   \n",
        "\n",
-       "       B LSTAT              target  \n",
-       "0  390.4  4.86  33.047000885009766  \n",
-       "1  389.2  6.05   33.95500183105469  "
+       "       B LSTAT             target  \n",
+       "0  390.4  4.86  32.94899999999999  \n",
+       "1  386.1  3.53  30.95299999999997  "
       ]
      },
      "metadata": {},
@@ -1309,17 +1302,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      "  0%|                                                                                            | 0/2 [00:00<?, ?it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
       "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
-      "WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
-      "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n"
+      " 50%|██████████████████████████████████████████                                          | 1/2 [00:00<00:00,  2.90it/s]WARNING:root: MAD for feature ZN is 0, so replacing it with 1.0 to avoid error.\n",
+      "WARNING:root: MAD for feature CHAS is 0, so replacing it with 1.0 to avoid error.\n",
+      "100%|████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  2.75it/s]"
      ]
     },
     {
@@ -1327,6 +1321,13 @@
      "output_type": "stream",
      "text": [
       "Query instance (original outcome : 49)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     },
     {
@@ -1382,7 +1383,7 @@
        "      <td>13.6</td>\n",
        "      <td>395.52</td>\n",
        "      <td>3.16</td>\n",
-       "      <td>49.108</td>\n",
+       "      <td>49.062</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1393,7 +1394,7 @@
        "0  0.01501  90.0   1.21   1.0  0.401  7.923  24.8  5.885  1.0  198.0     13.6   \n",
        "\n",
        "        B  LSTAT  target  \n",
-       "0  395.52   3.16  49.108  "
+       "0  395.52   3.16  49.062  "
       ]
      },
      "metadata": {},
@@ -1460,75 +1461,75 @@
        "      <td>-</td>\n",
        "      <td>395.5</td>\n",
        "      <td>-</td>\n",
-       "      <td>49.108001708984375</td>\n",
+       "      <td>-</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.02009</td>\n",
-       "      <td>95.0</td>\n",
-       "      <td>2.7</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>2.5</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.416</td>\n",
-       "      <td>8.034</td>\n",
-       "      <td>31.9</td>\n",
-       "      <td>5.118</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>224.0</td>\n",
-       "      <td>14.7</td>\n",
-       "      <td>390.5</td>\n",
-       "      <td>2.88</td>\n",
-       "      <td>49.50899887084961</td>\n",
+       "      <td>-</td>\n",
+       "      <td>7.61</td>\n",
+       "      <td>83.3</td>\n",
+       "      <td>2.741</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>395.6</td>\n",
+       "      <td>-</td>\n",
+       "      <td>44.443000000000026</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>0.0351</td>\n",
-       "      <td>95.0</td>\n",
-       "      <td>2.7</td>\n",
+       "      <td>-</td>\n",
+       "      <td>80.0</td>\n",
+       "      <td>0.5</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.416</td>\n",
-       "      <td>7.853</td>\n",
-       "      <td>33.2</td>\n",
-       "      <td>5.118</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>224.0</td>\n",
-       "      <td>14.7</td>\n",
-       "      <td>392.8</td>\n",
-       "      <td>3.81</td>\n",
-       "      <td>48.40999984741211</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>2.9</td>\n",
+       "      <td>1.1296</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>394.2</td>\n",
+       "      <td>1.73</td>\n",
+       "      <td>48.43299999999999</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>0.01538</td>\n",
        "      <td>-</td>\n",
-       "      <td>3.8</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.5</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.394</td>\n",
-       "      <td>7.454</td>\n",
-       "      <td>34.2</td>\n",
-       "      <td>6.3361</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>0.385</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
        "      <td>244.0</td>\n",
        "      <td>15.9</td>\n",
-       "      <td>386.3</td>\n",
-       "      <td>3.11</td>\n",
-       "      <td>43.03799819946289</td>\n",
+       "      <td>395.5</td>\n",
+       "      <td>-</td>\n",
+       "      <td>47.11500000000001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
-       "0        -     -   1.2    -      -      -     -       -    -      -       -   \n",
-       "1  0.02009  95.0   2.7  0.0  0.416  8.034  31.9   5.118  4.0  224.0    14.7   \n",
-       "2   0.0351  95.0   2.7  0.0  0.416  7.853  33.2   5.118  4.0  224.0    14.7   \n",
-       "3  0.01538     -   3.8  0.0  0.394  7.454  34.2  6.3361  3.0  244.0    15.9   \n",
+       "  CRIM    ZN INDUS CHAS    NOX    RM   AGE     DIS RAD    TAX PTRATIO      B  \\\n",
+       "0    -     -   1.2    -      -     -     -       -   -      -       -  395.5   \n",
+       "1    -     -   2.5  0.0      -  7.61  83.3   2.741   -      -       -  395.6   \n",
+       "2    -  80.0   0.5  0.0      -     -   2.9  1.1296   -      -       -  394.2   \n",
+       "3    -     -   0.5  0.0  0.385     -     -       -   -  244.0    15.9  395.5   \n",
        "\n",
-       "       B LSTAT              target  \n",
-       "0  395.5     -  49.108001708984375  \n",
-       "1  390.5  2.88   49.50899887084961  \n",
-       "2  392.8  3.81   48.40999984741211  \n",
-       "3  386.3  3.11   43.03799819946289  "
+       "  LSTAT              target  \n",
+       "0     -                   -  \n",
+       "1     -  44.443000000000026  \n",
+       "2  1.73   48.43299999999999  \n",
+       "3     -   47.11500000000001  "
       ]
      },
      "metadata": {},
@@ -1538,7 +1539,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Query instance (original outcome : 31)\n"
+      "Query instance (original outcome : 30)\n"
      ]
     },
     {
@@ -1594,7 +1595,7 @@
        "      <td>15.2</td>\n",
        "      <td>389.71</td>\n",
        "      <td>4.69</td>\n",
-       "      <td>30.827</td>\n",
+       "      <td>30.25</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1605,7 +1606,7 @@
        "0  0.06911  45.0   3.44   0.0  0.437  6.739  30.8  6.4798  5.0  398.0   \n",
        "\n",
        "   PTRATIO       B  LSTAT  target  \n",
-       "0     15.2  389.71   4.69  30.827  "
+       "0     15.2  389.71   4.69   30.25  "
       ]
      },
      "metadata": {},
@@ -1659,57 +1660,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.02009</td>\n",
-       "      <td>95.0</td>\n",
-       "      <td>2.7</td>\n",
-       "      <td>-</td>\n",
-       "      <td>0.416</td>\n",
-       "      <td>8.034</td>\n",
-       "      <td>31.9</td>\n",
-       "      <td>5.118</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>224.0</td>\n",
-       "      <td>14.7</td>\n",
-       "      <td>390.5</td>\n",
-       "      <td>2.88</td>\n",
-       "      <td>49.50899887084961</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.0351</td>\n",
-       "      <td>95.0</td>\n",
-       "      <td>2.7</td>\n",
-       "      <td>-</td>\n",
-       "      <td>0.416</td>\n",
-       "      <td>7.853</td>\n",
-       "      <td>33.2</td>\n",
-       "      <td>5.118</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>224.0</td>\n",
-       "      <td>14.7</td>\n",
-       "      <td>392.8</td>\n",
-       "      <td>3.81</td>\n",
-       "      <td>48.40999984741211</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.06129</td>\n",
-       "      <td>20.0</td>\n",
-       "      <td>3.3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>0.443</td>\n",
-       "      <td>7.645</td>\n",
-       "      <td>49.7</td>\n",
-       "      <td>5.2119</td>\n",
-       "      <td>-</td>\n",
-       "      <td>216.0</td>\n",
-       "      <td>14.9</td>\n",
-       "      <td>377.1</td>\n",
-       "      <td>3.01</td>\n",
-       "      <td>45.68299865722656</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
        "      <td>0.03578</td>\n",
        "      <td>20.0</td>\n",
        "      <td>3.3</td>\n",
@@ -1723,24 +1673,75 @@
        "      <td>14.9</td>\n",
        "      <td>387.3</td>\n",
        "      <td>3.76</td>\n",
-       "      <td>45.4640007019043</td>\n",
+       "      <td>45.901</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.00632</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>3.3</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.443</td>\n",
+       "      <td>7.82</td>\n",
+       "      <td>64.5</td>\n",
+       "      <td>4.6947</td>\n",
+       "      <td>-</td>\n",
+       "      <td>216.0</td>\n",
+       "      <td>14.9</td>\n",
+       "      <td>387.3</td>\n",
+       "      <td>3.76</td>\n",
+       "      <td>46.003</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.00632</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.422</td>\n",
+       "      <td>7.875</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>4.6947</td>\n",
+       "      <td>-</td>\n",
+       "      <td>216.0</td>\n",
+       "      <td>14.9</td>\n",
+       "      <td>387.3</td>\n",
+       "      <td>1.73</td>\n",
+       "      <td>48.361999999999995</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.00632</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>-</td>\n",
+       "      <td>0.422</td>\n",
+       "      <td>7.875</td>\n",
+       "      <td>2.9</td>\n",
+       "      <td>1.1296</td>\n",
+       "      <td>-</td>\n",
+       "      <td>187.0</td>\n",
+       "      <td>14.7</td>\n",
+       "      <td>396.9</td>\n",
+       "      <td>3.01</td>\n",
+       "      <td>48.59300000000001</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS  RAD    TAX PTRATIO  \\\n",
-       "0  0.02009  95.0   2.7    -  0.416  8.034  31.9   5.118  4.0  224.0    14.7   \n",
-       "1   0.0351  95.0   2.7    -  0.416  7.853  33.2   5.118  4.0  224.0    14.7   \n",
-       "2  0.06129  20.0   3.3  1.0  0.443  7.645  49.7  5.2119    -  216.0    14.9   \n",
-       "3  0.03578  20.0   3.3    -  0.443   7.82  64.5  4.6947    -  216.0    14.9   \n",
+       "      CRIM    ZN INDUS CHAS    NOX     RM   AGE     DIS RAD    TAX PTRATIO  \\\n",
+       "0  0.03578  20.0   3.3    -  0.443   7.82  64.5  4.6947   -  216.0    14.9   \n",
+       "1  0.00632  20.0   3.3    -  0.443   7.82  64.5  4.6947   -  216.0    14.9   \n",
+       "2  0.00632  20.0   0.5    -  0.422  7.875  32.0  4.6947   -  216.0    14.9   \n",
+       "3  0.00632  20.0   0.5    -  0.422  7.875   2.9  1.1296   -  187.0    14.7   \n",
        "\n",
-       "       B LSTAT             target  \n",
-       "0  390.5  2.88  49.50899887084961  \n",
-       "1  392.8  3.81  48.40999984741211  \n",
-       "2  377.1  3.01  45.68299865722656  \n",
-       "3  387.3  3.76   45.4640007019043  "
+       "       B LSTAT              target  \n",
+       "0  387.3  3.76              45.901  \n",
+       "1  387.3  3.76              46.003  \n",
+       "2  387.3  1.73  48.361999999999995  \n",
+       "3  396.9  3.01   48.59300000000001  "
       ]
      },
      "metadata": {},
@@ -1757,9 +1758,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:env1] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-env1-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1771,7 +1772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
+++ b/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
@@ -1758,9 +1758,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:env1] *",
    "language": "python",
-   "name": "python3
+   "name": "conda-env-env1-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1772,7 +1772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
+++ b/docs/source/notebooks/DiCE_multiclass_classification_and_regression.ipynb
@@ -1758,9 +1758,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:env1] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-env1-py"
+   "name": "python3
   },
   "language_info": {
    "codemirror_mode": {
@@ -1772,7 +1772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
the as_frame argument returns both X and y is one dataframe. Unfortunately for load_boston() doesn't support as_frame option.

Signed-off-by: gaugup <gaugup@microsoft.com>