### PR TITLE
Reduce number inferences in dice random

### DIFF
--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -65,16 +65,16 @@ class DiceRandom(ExplainerBase):
 
         # Do predictions once on the query_instance and reuse across to reduce the number
         # inferences.
-        modlel_predictions = self.predict_fn(query_instance)
+        model_predictions = self.predict_fn(query_instance)
 
         # number of output nodes of ML model
         self.num_output_nodes = None
         if self.model.model_type == "classifier":
-            self.num_output_nodes = modlel_predictions.shape[1]
+            self.num_output_nodes = model_predictions.shape[1]
 
         # query_instance need no transformation for generating CFs using random sampling.
         # find the predicted value of query_instance
-        test_pred = modlel_predictions[0]
+        test_pred = model_predictions[0]
         if self.model.model_type == 'classifier':
             self.target_cf_class = self.infer_target_cfs_class(desired_class, test_pred, self.num_output_nodes)
         elif self.model.model_type == 'regressor':

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -63,6 +63,8 @@ class DiceRandom(ExplainerBase):
         else: # compute the new ranges based on user input
             self.feature_range, feature_ranges_orig = self.data_interface.get_features_range(permitted_range)
 
+        # Do predictions once on the query_instance and reuse across to reduce the number
+        # inferences.
         modlel_predictions = self.predict_fn(query_instance)
 
         # number of output nodes of ML model

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -63,14 +63,16 @@ class DiceRandom(ExplainerBase):
         else: # compute the new ranges based on user input
             self.feature_range, feature_ranges_orig = self.data_interface.get_features_range(permitted_range)
 
+        modlel_predictions = self.predict_fn(query_instance)
+
         # number of output nodes of ML model
         self.num_output_nodes = None
         if self.model.model_type == "classifier":
-            self.num_output_nodes = self.predict_fn(query_instance).shape[1]
+            self.num_output_nodes = modlel_predictions.shape[1]
 
         # query_instance need no transformation for generating CFs using random sampling.
         # find the predicted value of query_instance
-        test_pred = self.predict_fn(query_instance)[0]
+        test_pred = modlel_predictions[0]
         if self.model.model_type == 'classifier':
             self.target_cf_class = self.infer_target_cfs_class(desired_class, test_pred, self.num_output_nodes)
         elif self.model.model_type == 'regressor':


### PR DESCRIPTION
It seems like major time while computing counterfactuals in DiceRandom class is spent in calling get_output(). Hence, reducing the number of calls to get_couput() will reduce the run time. The PR does one call to get_output() for the query point and caches the result so that it can be reused across the computation of counterfactuals for that point. This optimizes the classification scenario only for now. 