### PR TITLE
Add user validations to dice-ml model interface

### DIFF
--- a/dice_ml/constants.py
+++ b/dice_ml/constants.py
@@ -7,11 +7,20 @@ class BackEndTypes:
     Tensorflow2 = 'TF2'
     Pytorch = 'PYT'
 
+    ALL = [Sklearn, Tensorflow1, Tensorflow2, Pytorch]
+
 
 class SamplingStrategy:
     Random = 'random'
     Genetic = 'genetic'
     KdTree = 'kdtree'
+
+
+class ModelTypes:
+    Classifier = 'classifier'
+    Regressor = 'regressor'
+
+    ALL = [Classifier, Regressor]
 
 
 class _SchemaVersions:

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -2,7 +2,7 @@ import pandas as pd
 import copy
 import json
 from dice_ml.utils.serialize import DummyDataInterface
-from dice_ml.constants import _SchemaVersions
+from dice_ml.constants import _SchemaVersions, ModelTypes
 
 
 class _DiverseCFV1SchemaConstants:
@@ -37,7 +37,7 @@ def json_converter(obj):
 class CounterfactualExamples:
     """A class to store and visualize the resulting counterfactual explanations."""
 
-    def __init__(self, data_interface=None, final_cfs_df=None, test_instance_df=None, final_cfs_df_sparse=None, posthoc_sparsity_param=0, desired_range=None, desired_class="opposite", model_type='classifier'):
+    def __init__(self, data_interface=None, final_cfs_df=None, test_instance_df=None, final_cfs_df_sparse=None, posthoc_sparsity_param=0, desired_range=None, desired_class="opposite", model_type=ModelTypes.Classifier):
 
         self.data_interface = data_interface
         self.final_cfs_df = final_cfs_df
@@ -51,12 +51,12 @@ class CounterfactualExamples:
         self.posthoc_sparsity_param = posthoc_sparsity_param # might be useful for future additions
 
         self.test_pred = self.test_instance_df[self.data_interface.outcome_name].iat[0]
-        if model_type == 'classifier':
+        if model_type == ModelTypes.Classifier:
             if desired_class == "opposite":
                 self.new_outcome = 1.0 - round(self.test_pred)
             else:
                 self.new_outcome = desired_class
-        elif model_type == 'regressor':
+        elif model_type == ModelTypes.Regressor:
             self.new_outcome = desired_range
 
     def __eq__(self, other_counterfactual_example):

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -10,6 +10,7 @@ import copy
 import random
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.constants import ModelTypes
 
 
 class DiceKD(ExplainerBase):
@@ -37,7 +38,7 @@ class DiceKD(ExplainerBase):
         self.model.load_model()
 
         # number of output nodes of ML model
-        if self.model.model_type == 'classifier':
+        if self.model.model_type == ModelTypes.Classifier:
             self.num_output_nodes = self.model.get_num_output_nodes2(
                 self.data_interface.data_df[0:1][self.data_interface.feature_names])
 
@@ -82,7 +83,7 @@ class DiceKD(ExplainerBase):
             if desired_range[0] > desired_range[1]:
                 raise ValueError("Invalid Range!")
 
-        if desired_class == "opposite" and self.model.model_type == 'classifier':
+        if desired_class == "opposite" and self.model.model_type == ModelTypes.Classifier:
             if self.num_output_nodes == 2:
                 desired_class = 1.0 - test_pred
 

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -12,6 +12,7 @@ import copy
 from sklearn.preprocessing import LabelEncoder
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.constants import ModelTypes
 
 
 class DiceGenetic(ExplainerBase):
@@ -27,7 +28,7 @@ class DiceGenetic(ExplainerBase):
         super().__init__(data_interface, model_interface)  # initiating data related parameters
 
         # number of output nodes of ML model
-        if self.model.model_type == 'classifier':
+        if self.model.model_type == ModelTypes.Classifier:
             self.num_output_nodes = self.model.get_num_output_nodes2(
                 self.data_interface.data_df[0:1][self.data_interface.feature_names])
 
@@ -282,7 +283,7 @@ class DiceGenetic(ExplainerBase):
     def compute_yloss(self, cfs, desired_range, desired_class):
         """Computes the first part (y-loss) of the loss function."""
         yloss = 0.0
-        if self.model.model_type == 'classifier':
+        if self.model.model_type == ModelTypes.Classifier:
             predicted_value = np.array(self.predict_fn_scores(cfs))
             if self.yloss_type == 'hinge_loss':
                 maxvalue = np.full((len(predicted_value)), -np.inf)
@@ -292,7 +293,7 @@ class DiceGenetic(ExplainerBase):
                 yloss = np.maximum(0, maxvalue - predicted_value[:, int(desired_class)])
             return yloss
 
-        elif self.model.model_type == 'regressor':
+        elif self.model.model_type == ModelTypes.Regressor:
             predicted_value = self.predict_fn(cfs)
             if self.yloss_type == 'hinge_loss':
                 yloss = np.zeros(len(predicted_value))
@@ -369,7 +370,7 @@ class DiceGenetic(ExplainerBase):
         to_pred = None
 
         while iterations < maxiterations and self.total_CFs > 0:
-            if abs(previous_best_loss - current_best_loss) <= thresh and (self.model.model_type == 'classifier' and all(i == desired_class for i in cfs_preds) or (self.model.model_type == 'regressor' and all(desired_range[0] <= i <= desired_range[1] for i in cfs_preds))):
+            if abs(previous_best_loss - current_best_loss) <= thresh and (self.model.model_type == ModelTypes.Classifier and all(i == desired_class for i in cfs_preds) or (self.model.model_type == ModelTypes.Regressor and all(desired_range[0] <= i <= desired_range[1] for i in cfs_preds))):
                 stop_cnt += 1
             else:
                 stop_cnt = 0

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -14,6 +14,7 @@ import copy
 from sklearn.preprocessing import LabelEncoder
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.constants import ModelTypes
 
 
 class DiceRandom(ExplainerBase):
@@ -69,15 +70,15 @@ class DiceRandom(ExplainerBase):
 
         # number of output nodes of ML model
         self.num_output_nodes = None
-        if self.model.model_type == "classifier":
+        if self.model.model_type == ModelTypes.Classifier:
             self.num_output_nodes = model_predictions.shape[1]
 
         # query_instance need no transformation for generating CFs using random sampling.
         # find the predicted value of query_instance
         test_pred = model_predictions[0]
-        if self.model.model_type == 'classifier':
+        if self.model.model_type == ModelTypes.Classifier:
             self.target_cf_class = self.infer_target_cfs_class(desired_class, test_pred, self.num_output_nodes)
-        elif self.model.model_type == 'regressor':
+        elif self.model.model_type == ModelTypes.Regressor:
             self.target_cf_range = self.infer_target_cfs_range(desired_range)
         # fixing features that are to be fixed
         self.total_CFs = total_CFs
@@ -92,7 +93,7 @@ class DiceRandom(ExplainerBase):
                     self.fixed_features_values[feature] = query_instance[feature].iat[0]
 
         self.stopping_threshold = stopping_threshold
-        if self.model.model_type == "classifier":
+        if self.model.model_type == ModelTypes.Classifier:
             # TODO Generalize this for multi-class
             if self.target_cf_class == 0 and self.stopping_threshold > 0.5:
                 self.stopping_threshold = 0.25

--- a/dice_ml/model.py
+++ b/dice_ml/model.py
@@ -3,7 +3,7 @@
 The implementations contain methods to access the output or gradients of ML models trained based on different
 frameworks such as Tensorflow or PyTorch.
 """
-
+import warnings
 from dice_ml.constants import BackEndTypes, ModelTypes
 from dice_ml.utils.exception import UserConfigValidationException
 
@@ -30,7 +30,7 @@ class Model:
                         to the dictionary of kw_args, by default.
         """
         if backend not in BackEndTypes.ALL:
-            raise UserConfigValidationException('{0} backend not in supported backends {1}'.format(
+            warnings.warn('{0} backend not in supported backends {1}'.format(
                 backend, ','.join(BackEndTypes.ALL))
             )
 

--- a/dice_ml/model.py
+++ b/dice_ml/model.py
@@ -10,7 +10,8 @@ from dice_ml.utils.exception import UserConfigValidationException
 
 class Model:
     """An interface class to different ML Model implementations."""
-    def __init__(self, model=None, model_path='', backend=BackEndTypes.Tensorflow1, model_type=ModelTypes.Classifier, func=None, kw_args=None):
+    def __init__(self, model=None, model_path='', backend=BackEndTypes.Tensorflow1, model_type=ModelTypes.Classifier,
+                 func=None, kw_args=None):
         """Init method
 
         :param model: trained ML model.

--- a/dice_ml/model.py
+++ b/dice_ml/model.py
@@ -3,13 +3,13 @@
 The implementations contain methods to access the output or gradients of ML models trained based on different frameworks such as Tensorflow or PyTorch.
 """
 
-from dice_ml.constants import BackEndTypes
+from dice_ml.constants import BackEndTypes, ModelTypes
 from dice_ml.utils.exception import UserConfigValidationException
 
 
 class Model:
     """An interface class to different ML Model implementations."""
-    def __init__(self, model=None, model_path='', backend='TF1', model_type='classifier', func=None, kw_args=None):
+    def __init__(self, model=None, model_path='', backend=BackEndTypes.Tensorflow1, model_type=ModelTypes.Classifier, func=None, kw_args=None):
         """Init method
 
         :param model: trained ML model.
@@ -18,6 +18,16 @@ class Model:
         :param func: function transformation required for ML model. If func is None, then func will be the identity function.
         :param kw_args: Dictionary of additional keyword arguments to pass to func. DiCE's data_interface is appended to the dictionary of kw_args, by default.
         """
+        if backend not in BackEndTypes.ALL:
+            raise UserConfigValidationException('{0} backend not in supported backends {1}'.format(
+                backend, ','.join(BackEndTypes.ALL))
+            )
+
+        if model_type not in ModelTypes.ALL:
+            raise UserConfigValidationException('{0} model type not in supported model types {1}'.format(
+                model_type, ','.join(ModelTypes.ALL))
+            )
+
         self.model_type = model_type
         if((model is None) & (model_path == '')):
             raise ValueError("should provide either a trained model or the path to a model")

--- a/dice_ml/model_interfaces/base_model.py
+++ b/dice_ml/model_interfaces/base_model.py
@@ -8,7 +8,6 @@ from dice_ml.utils.helpers import DataTransfomer
 from dice_ml.constants import ModelTypes
 
 
-
 class BaseModel:
 
     def __init__(self, model=None, model_path='', backend='', func=None, kw_args=None):

--- a/dice_ml/model_interfaces/base_model.py
+++ b/dice_ml/model_interfaces/base_model.py
@@ -5,6 +5,8 @@
 import pickle
 import numpy as np
 from dice_ml.utils.helpers import DataTransfomer
+from dice_ml.constants import ModelTypes
+
 
 class BaseModel:
 
@@ -36,7 +38,7 @@ class BaseModel:
         array of predicted value for a regressor.
         """
         input_instance = self.transformer.transform(input_instance)
-        if self.model_type == "classifier":
+        if self.model_type == ModelTypes.Classifier:
             return self.model.predict_proba(input_instance)
         else:
             return self.model.predict(input_instance)

--- a/dice_ml/model_interfaces/base_model.py
+++ b/dice_ml/model_interfaces/base_model.py
@@ -62,6 +62,6 @@ class BaseModel:
         return self.get_output(temp_input).shape[1]
 
     def get_num_output_nodes2(self, input):
-        if self.model_type == 'regressor':
+        if self.model_type == ModelTypes.Regressor:
             raise SystemException('Number of output nodes not supported for regression')
         return self.get_output(input).shape[1]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,8 @@ import pytest
 
 import dice_ml
 from dice_ml.utils import helpers
+from sklearn.ensemble import RandomForestClassifier
+from dice_ml.utils.exception import UserConfigValidationException
 
 
 class TestBaseModelLoader:
@@ -29,3 +31,27 @@ class TestBaseModelLoader:
         backend = 'sklearn'
         m = self._get_model(backend)
         assert isinstance(m, dice_ml.model_interfaces.base_model.BaseModel)
+
+
+class TestModelUserValidations:
+
+    def create_sklearn_random_forest_classifier(self, X, y):
+        rfc = RandomForestClassifier(n_estimators=10, max_depth=4,
+                                     random_state=777)
+        model = rfc.fit(X, y)
+        return model
+
+    def test_model_user_validation_model_type(self, create_iris_data):
+        x_train, x_test, y_train, y_test, feature_names, classes = \
+            create_iris_data
+        trained_model = self.create_sklearn_random_forest_classifier(x_train, y_train)
+
+        assert dice_ml.Model(model=trained_model, backend='sklearn', model_type='classifier') is not None
+        assert dice_ml.Model(model=trained_model, backend='sklearn', model_type='regressor') is not None
+
+        with pytest.raises(UserConfigValidationException):
+            dice_ml.Model(model=trained_model, backend='sklearn', model_type='random')
+
+    def test_model_user_validation_no_valid_model(self):
+        with pytest.raises(ValueError):
+            dice_ml.Model(backend='sklearn')


### PR DESCRIPTION
- Add user validations to dice-ml model interface to validate backend and model_type
- Reduce cyclometric complexity of is_cf_valid() to below 10.
- Add constants for 'classifier' and 'regressor'
- Added tests for validation of backend and model_type.

Signed-off-by: gaugup <gaugup@microsoft.com>