### PR TITLE
Make ExplainerBase Abstract Class

### DIFF
--- a/dice_ml/dice.py
+++ b/dice_ml/dice.py
@@ -4,9 +4,10 @@
 
 from dice_ml.constants import BackEndTypes, SamplingStrategy
 from dice_ml.utils.exception import UserConfigValidationException
+from dice_ml.explainer_interfaces.explainer_base import ExplainerBase
 
 
-class Dice:
+class Dice(ExplainerBase):
     """An interface class to different DiCE implementations."""
 
     def __init__(self, data_interface, model_interface, method="random",  **kwargs):
@@ -22,6 +23,13 @@ class Dice:
         """Decides DiCE implementation type."""
         self.__class__ = decide(model_interface, method)
         self.__init__(data_interface, model_interface, **kwargs)
+
+    def _generate_counterfactuals(self, query_instance, total_CFs,
+                                  desired_class="opposite", desired_range=None,
+                                  permitted_range=None, features_to_vary="all",
+                                  stopping_threshold=0.5, posthoc_sparsity_param=0.1,
+                                  posthoc_sparsity_algorithm="linear", verbose=False, **kwargs):
+        pass
 
 
 def decide(model_interface, method):

--- a/dice_ml/dice.py
+++ b/dice_ml/dice.py
@@ -29,7 +29,8 @@ class Dice(ExplainerBase):
                                   permitted_range=None, features_to_vary="all",
                                   stopping_threshold=0.5, posthoc_sparsity_param=0.1,
                                   posthoc_sparsity_algorithm="linear", verbose=False, **kwargs):
-        pass
+        raise NotImplementedError("This method should be implemented by the concrete classes "
+                                  "that inherit from ExplainerBase")
 
 
 def decide(model_interface, method):

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -2,6 +2,7 @@
    Subclasses implement interfaces for different ML frameworks such as TensorFlow or PyTorch.
    All methods are in dice_ml.explainer_interfaces"""
 
+from abc import ABC, abstractmethod
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -12,7 +13,7 @@ from dice_ml.counterfactual_explanations import CounterfactualExplanations
 from dice_ml.utils.exception import UserConfigValidationException
 
 
-class ExplainerBase:
+class ExplainerBase(ABC):
 
     def __init__(self, data_interface, model_interface=None):
         """Init method
@@ -53,7 +54,6 @@ class ExplainerBase:
         :param query_instances: Input point(s) for which counterfactuals are to be generated.
                                 This can be a dataframe with one or more rows.
         :param total_CFs: Total number of counterfactuals required.
-
         :param desired_class: Desired counterfactual class - can take 0 or 1. Default value
                               is "opposite" to the outcome class of query_instance for binary classification.
         :param desired_range: For regression problems. Contains the outcome range to
@@ -74,7 +74,7 @@ class ExplainerBase:
         :param kwargs: Other parameters accepted by specific explanation method
 
         :returns: A CounterfactualExplanations object that contains the list of
-        counterfactual examples per query_instance as one of its attributes.
+                  counterfactual examples per query_instance as one of its attributes.
         """
         if total_CFs <= 0:
             raise UserConfigValidationException(
@@ -100,6 +100,42 @@ class ExplainerBase:
                 **kwargs)
             cf_examples_arr.append(res)
         return CounterfactualExplanations(cf_examples_list=cf_examples_arr)
+
+    @abstractmethod
+    def _generate_counterfactuals(self, query_instance, total_CFs,
+                                  desired_class="opposite", desired_range=None,
+                                  permitted_range=None, features_to_vary="all",
+                                  stopping_threshold=0.5, posthoc_sparsity_param=0.1,
+                                  posthoc_sparsity_algorithm="linear", verbose=False, **kwargs):
+        """Internal method for generating counterfactuals for a given query instance. Any explainerclass
+           inherting from this class would need to implement this abstract method.
+
+        :param query_instance: Input point for which counterfactuals are to be generated.
+                               This can be a dataframe with one row.
+        :param total_CFs: Total number of counterfactuals required.
+        :param desired_class: Desired counterfactual class - can take 0 or 1. Default value
+                              is "opposite" to the outcome class of query_instance for binary classification.
+        :param desired_range: For regression problems. Contains the outcome range to
+                              generate counterfactuals in.
+        :param permitted_range: Dictionary with feature names as keys and permitted range in list as values.
+                                Defaults to the range inferred from training data.
+                                If None, uses the parameters initialized in data_interface.
+        :param features_to_vary: Either a string "all" or a list of feature names to vary.
+        :param stopping_threshold: Minimum threshold for counterfactuals target class probability.
+        :param posthoc_sparsity_param: Parameter for the post-hoc operation on continuous features to enhance sparsity.
+        :param posthoc_sparsity_algorithm: Perform either linear or binary search. Takes "linear" or "binary".
+                                           Prefer binary search when a feature range is large (for instance,
+                                           income varying from 10k to 1000k) and only if the features share a
+                                           monotonic relationship with predicted outcome in the model.
+        :param verbose: Whether to output detailed messages.
+        :param sample_size: Sampling size
+        :param random_seed: Random seed for reproducibility
+        :param kwargs: Other parameters accepted by specific explanation method
+
+        :returns: A CounterfactualExplanations object that contains the list of
+                  counterfactual examples per query_instance as one of its attributes.
+        """
+        pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
         if features_to_vary == 'all':

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -1,5 +1,6 @@
 import pytest
 from dice_ml.utils.exception import UserConfigValidationException
+from dice_ml.explainer_interfaces.explainer_base import ExplainerBase
 
 
 class TestExplainerBaseBinaryClassification:
@@ -42,3 +43,10 @@ class TestExplainerBaseRegression:
                     query_instances=[sample_custom_query_1],
                     total_CFs=0,
                     desired_class=desired_class)
+
+
+class TestExplainerBase:
+
+    def test_instantiating_explainer_base(self, public_data_object):
+        with pytest.raises(TypeError):
+            ExplainerBase(data_interface=public_data_object)


### PR DESCRIPTION
The ExplainerBase class doesn't implement _generate_counterfactuals() but expects derived classes to implement this function. Hence, making ExplainerBase class an abstract class and making the method _generate_counterfactuals() an abstract method so that the deriving class always implements it.

Signed-off-by: gaugup <gaugup@microsoft.com>