### PR TITLE
Return CounterfactualExplanations from tensorflow and pytorch explainers

### DIFF
--- a/dice_ml/explainer_interfaces/dice_pytorch.py
+++ b/dice_ml/explainer_interfaces/dice_pytorch.py
@@ -10,6 +10,7 @@ import timeit
 import copy
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.counterfactual_explanations import CounterfactualExplanations
 
 
 class DicePyTorch(ExplainerBase):
@@ -127,12 +128,15 @@ class DicePyTorch(ExplainerBase):
                 project_iter, loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance,
                 tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
-        return exp.CounterfactualExamples(data_interface=self.data_interface,
-                                          final_cfs_df=final_cfs_df,
-                                          test_instance_df=test_instance_df,
-                                          final_cfs_df_sparse=final_cfs_df_sparse,
-                                          posthoc_sparsity_param=posthoc_sparsity_param,
-                                          desired_class=desired_class)
+        counterfactual_explanations = exp.CounterfactualExamples(
+            data_interface=self.data_interface,
+            final_cfs_df=final_cfs_df,
+            test_instance_df=test_instance_df,
+            final_cfs_df_sparse=final_cfs_df_sparse,
+            posthoc_sparsity_param=posthoc_sparsity_param,
+            desired_class=desired_class)
+
+        return CounterfactualExplanations(cf_examples_list=[counterfactual_explanations])
 
     def get_model_output(self, input_instance):
         """get output probability of ML model"""

--- a/dice_ml/explainer_interfaces/dice_tensorflow1.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow1.py
@@ -11,6 +11,7 @@ import timeit
 import copy
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.counterfactual_explanations import CounterfactualExplanations
 
 
 class DiceTensorFlow1(ExplainerBase):
@@ -159,12 +160,15 @@ class DiceTensorFlow1(ExplainerBase):
             loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance, tie_random,
             stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
-        return exp.CounterfactualExamples(data_interface=self.data_interface,
-                                          final_cfs_df=final_cfs_df,
-                                          test_instance_df=test_instance_df,
-                                          final_cfs_df_sparse=final_cfs_df_sparse,
-                                          posthoc_sparsity_param=posthoc_sparsity_param,
-                                          desired_class=desired_class)
+        counterfactual_explanations = exp.CounterfactualExamples(
+            data_interface=self.data_interface,
+            final_cfs_df=final_cfs_df,
+            test_instance_df=test_instance_df,
+            final_cfs_df_sparse=final_cfs_df_sparse,
+            posthoc_sparsity_param=posthoc_sparsity_param,
+            desired_class=desired_class)
+
+        return CounterfactualExplanations(cf_examples_list=[counterfactual_explanations])
 
     def do_cf_initializations(self, total_CFs, algorithm, features_to_vary):
         """Intializes TF variables required for CF generation."""

--- a/dice_ml/explainer_interfaces/dice_tensorflow2.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow2.py
@@ -10,6 +10,7 @@ import timeit
 import copy
 
 from dice_ml import diverse_counterfactuals as exp
+from dice_ml.counterfactual_explanations import CounterfactualExplanations
 
 
 class DiceTensorFlow2(ExplainerBase):
@@ -132,12 +133,15 @@ class DiceTensorFlow2(ExplainerBase):
                                       init_near_query_instance, tie_random, stopping_threshold,
                                       posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
-        return exp.CounterfactualExamples(data_interface=self.data_interface,
-                                          final_cfs_df=final_cfs_df,
-                                          test_instance_df=test_instance_df,
-                                          final_cfs_df_sparse=final_cfs_df_sparse,
-                                          posthoc_sparsity_param=posthoc_sparsity_param,
-                                          desired_class=desired_class)
+        counterfactual_explanations = exp.CounterfactualExamples(
+            data_interface=self.data_interface,
+            final_cfs_df=final_cfs_df,
+            test_instance_df=test_instance_df,
+            final_cfs_df_sparse=final_cfs_df_sparse,
+            posthoc_sparsity_param=posthoc_sparsity_param,
+            desired_class=desired_class)
+
+        return CounterfactualExplanations(cf_examples_list=[counterfactual_explanations])
 
     def predict_fn(self, input_instance):
         """prediction function"""

--- a/tests/test_dice_interface/test_dice_pytorch.py
+++ b/tests/test_dice_interface/test_dice_pytorch.py
@@ -3,6 +3,8 @@ import pytest
 
 import dice_ml
 from dice_ml.utils import helpers
+from dice_ml.counterfactual_explanations import CounterfactualExplanations
+
 
 torch = pytest.importorskip("torch")
 
@@ -66,7 +68,9 @@ class TestDiceTorchMethods:
         """
         Tets correctness of final CFs and their predictions for sample query instance.
         """
-        self.exp.generate_counterfactuals(sample_adultincome_query, total_CFs=4, desired_class="opposite")
+        counterfactual_explanations = self.exp.generate_counterfactuals(
+            sample_adultincome_query, total_CFs=4, desired_class="opposite")
+        assert isinstance(counterfactual_explanations, CounterfactualExplanations)
         # test_cfs = [[72.0, 'Private', 'HS-grad', 'Married', 'White-Collar', 'White', 'Female', 45.0, 0.691],
         #             [29.0, 'Private', 'Prof-school', 'Married', 'Service', 'White', 'Male', 45.0, 0.954],
         #             [52.0, 'Private', 'Doctorate', 'Married', 'Service', 'White', 'Female', 45.0, 0.971],

--- a/tests/test_dice_interface/test_dice_tensorflow.py
+++ b/tests/test_dice_interface/test_dice_tensorflow.py
@@ -3,6 +3,8 @@ import pytest
 
 import dice_ml
 from dice_ml.utils import helpers
+from dice_ml.counterfactual_explanations import CounterfactualExplanations
+
 
 tf = pytest.importorskip("tensorflow")
 
@@ -90,7 +92,9 @@ class TestDiceTensorFlowMethods:
         """
         Tets correctness of final CFs and their predictions for sample query instance.
         """
-        self.exp.generate_counterfactuals(sample_adultincome_query, total_CFs=4, desired_class="opposite")
+        counterfactual_explanations = self.exp.generate_counterfactuals(
+            sample_adultincome_query, total_CFs=4, desired_class="opposite")
+        assert isinstance(counterfactual_explanations, CounterfactualExplanations)
         # test_cfs = [[70.0, 'Private', 'Masters', 'Single', 'White-Collar', 'White', 'Female', 51.0, 0.534],
         #             [22.0, 'Self-Employed', 'Doctorate', 'Married', 'Service', 'White', 'Female', 45.0, 0.861],
         #             [47.0, 'Private', 'HS-grad', 'Married', 'Service', 'White', 'Female', 45.0, 0.589],


### PR DESCRIPTION
Seems like generate_counterfactuals() in dice_tensorflow1.py,  dice_tensorflow2.py and  dice_pytorch.py return CounterfactualExamples. This has integration issues when the customers use this output to compute feature importance. Hence, changing the return type in these function to return CounterfactualExplanations.

This is related to the github issue https://github.com/interpretml/DiCE/issues/155.

Signed-off-by: gaugup <gaugup@microsoft.com>