### PR TITLE
Added checks for dice_random

### DIFF
--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -132,13 +132,8 @@ class DiceRandom(ExplainerBase):
             if len(cfs_df) > total_CFs:
                 cfs_df = cfs_df.sample(total_CFs)
             cfs_df.reset_index(inplace=True, drop=True)
-            if len(cfs_df) > 0:
-                self.cfs_pred_scores = self.predict_fn(cfs_df)
-            else:
-                if self.model.model_type == ModelTypes.Classifier:
-                    self.cfs_pred_scores = [0]*self.num_output_nodes
-                else:
-                    self.cfs_pred_scores = [0]
+            self.cfs_pred_scores = self.predict_fn(cfs_df)
+
             cfs_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.cfs_pred_scores)
 
             self.total_cfs_found = len(cfs_df)

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -132,8 +132,13 @@ class DiceRandom(ExplainerBase):
             if len(cfs_df) > total_CFs:
                 cfs_df = cfs_df.sample(total_CFs)
             cfs_df.reset_index(inplace=True, drop=True)
-            self.cfs_pred_scores = self.predict_fn(cfs_df)
-
+            if len(cfs_df) > 0:
+                self.cfs_pred_scores = self.predict_fn(cfs_df)
+            else:
+                if self.model.model_type == ModelTypes.Classifier:
+                    self.cfs_pred_scores = [0]*self.num_output_nodes
+                else:
+                    self.cfs_pred_scores = [0]
             cfs_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.cfs_pred_scores)
 
             self.total_cfs_found = len(cfs_df)

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -60,12 +60,16 @@ class DiceRandom(ExplainerBase):
 
         :returns: A CounterfactualExamples object that contains the dataframe of generated counterfactuals as an attribute.
         """
-        if permitted_range is None:
-            # use the precomputed default
-            self.feature_range = self.data_interface.permitted_range
+        self.features_to_vary = self.setup(features_to_vary, permitted_range, query_instance, feature_weights=None)
+
+        if features_to_vary == "all":
+            self.fixed_features_values = {}
         else:
-            # compute the new ranges based on user input
-            self.feature_range, feature_ranges_orig = self.data_interface.get_features_range(permitted_range)
+            self.fixed_features_values = {}
+            for feature in self.data_interface.feature_names:
+                if feature not in features_to_vary:
+                    self.fixed_features_values[feature] = query_instance[feature].iat[0]
+
 
         # Do predictions once on the query_instance and reuse across to reduce the number
         # inferences.
@@ -85,15 +89,6 @@ class DiceRandom(ExplainerBase):
             self.target_cf_range = self.infer_target_cfs_range(desired_range)
         # fixing features that are to be fixed
         self.total_CFs = total_CFs
-        self.features_to_vary = features_to_vary
-        if features_to_vary == "all":
-            self.features_to_vary = self.data_interface.feature_names
-            self.fixed_features_values = {}
-        else:
-            self.fixed_features_values = {}
-            for feature in self.data_interface.feature_names:
-                if feature not in features_to_vary:
-                    self.fixed_features_values[feature] = query_instance[feature].iat[0]
 
         self.stopping_threshold = stopping_threshold
         if self.model.model_type == ModelTypes.Classifier:
@@ -138,7 +133,13 @@ class DiceRandom(ExplainerBase):
             if len(cfs_df) > total_CFs:
                 cfs_df = cfs_df.sample(total_CFs)
             cfs_df.reset_index(inplace=True, drop=True)
-            self.cfs_pred_scores = self.predict_fn(cfs_df)
+            if len(cfs_df) > 0:
+                self.cfs_pred_scores = self.predict_fn(cfs_df)
+            else:
+                if self.model.model_type == ModelTypes.Classifier:
+                    self.cfs_pred_scores = [0]*self.num_output_nodes
+                else:
+                    self.cfs_pred_scores = [0]
             cfs_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.cfs_pred_scores)
 
             self.total_cfs_found = len(cfs_df)

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -233,4 +233,3 @@ class DiceRandom(ExplainerBase):
             result = np.random.uniform(low, high+(10**-precision), size)
             result = [round(r, precision) for r in result]
         return result
-    

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -70,7 +70,6 @@ class DiceRandom(ExplainerBase):
                 if feature not in features_to_vary:
                     self.fixed_features_values[feature] = query_instance[feature].iat[0]
 
-
         # Do predictions once on the query_instance and reuse across to reduce the number
         # inferences.
         model_predictions = self.predict_fn(query_instance)
@@ -234,3 +233,4 @@ class DiceRandom(ExplainerBase):
             result = np.random.uniform(low, high+(10**-precision), size)
             result = [round(r, precision) for r in result]
         return result
+    

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -155,6 +155,10 @@ class ExplainerBase(ABC):
         return features_to_vary
 
     def check_query_instance_validity(self, features_to_vary, permitted_range, query_instance, feature_ranges_orig):
+        for feature in query_instance:
+            if feature not in self.data_interface.feature_names:
+                raise ValueError("Feature", feature, "not present in training data!")
+
         for feature in self.data_interface.categorical_feature_names:
             if query_instance[feature].values[0] not in feature_ranges_orig[feature]:
                 raise ValueError("Feature", feature, "has a value outside the dataset.")

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -20,7 +20,7 @@ def load_adult_income_dataset(only_train=True):
     :return adult_data: returns preprocessed adult income dataset.
     """
     raw_data = np.genfromtxt('https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data',
-                             delimiter=', ', dtype=str)
+                             delimiter=', ', dtype=str, invalid_raise=False)
 
     #  column names from "https://archive.ics.uci.edu/ml/datasets/Adult"
     column_names = ['age', 'workclass', 'fnlwgt', 'education', 'educational-num', 'marital-status', 'occupation',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,13 @@ def sample_custom_query_3():
     """
     return pd.DataFrame({'Categorical': ['d'], 'Numerical': [1000000]})
 
+@pytest.fixture
+def sample_custom_query_5():
+    """
+    Returns a sample query instance for the custom dataset
+    """
+    return pd.DataFrame({'X': ['d'], 'Numerical': [25]})
+
 
 @pytest.fixture
 def sample_custom_query_4():
@@ -117,7 +124,7 @@ def sample_custom_query_10():
     """
     return pd.DataFrame(
         {
-            'Categorical': ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+            'Categorical': ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c', 'a'],
             'Numerical': [25, 50, 75, 100, 125, 150, 175, 200, 225, 250]
         }
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,7 @@ def sample_custom_query_3():
     """
     return pd.DataFrame({'Categorical': ['d'], 'Numerical': [1000000]})
 
+
 @pytest.fixture
 def sample_custom_query_5():
     """

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -124,6 +124,13 @@ class TestDiceKDBinaryClassificationMethods:
             self.exp._generate_counterfactuals(query_instance=sample_custom_query_3, total_CFs=total_CFs,
                                                desired_class=desired_class)
 
+    # Testing if an error is thrown when the query instance has an unknown column
+    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
+    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_5, total_CFs):
+        with pytest.raises(ValueError):
+            self.exp._generate_counterfactuals(query_instance=sample_custom_query_5, total_CFs=total_CFs,
+                                               desired_class=desired_class)
+
     # Ensuring that there are no duplicates in the resulting counterfactuals even if the dataset has duplicates
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 2)])
     def test_duplicates(self, desired_class, sample_custom_query_4, total_CFs):

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -126,7 +126,7 @@ class TestDiceKDBinaryClassificationMethods:
 
     # Testing if an error is thrown when the query instance has an unknown column
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_5, total_CFs):
+    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs):
         with pytest.raises(ValueError):
             self.exp._generate_counterfactuals(query_instance=sample_custom_query_5, total_CFs=total_CFs,
                                                desired_class=desired_class)

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -122,7 +122,7 @@ class TestDiceGeneticBinaryClassificationMethods:
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_5, total_CFs):
+    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs):
         with pytest.raises(ValueError):
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
 

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -122,7 +122,7 @@ class TestDiceRandomBinaryClassificationMethods:
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_5, total_CFs):
+    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs):
         with pytest.raises(ValueError):
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
 

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -102,7 +102,7 @@ class TestDiceRandomBinaryClassificationMethods:
 
         for feature in permitted_range:
             assert all(
-              permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
                 in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -5,42 +5,42 @@ from dice_ml.utils.exception import UserConfigValidationException
 
 
 @pytest.fixture
-def genetic_binary_classification_exp_object():
+def random_binary_classification_exp_object():
     backend = 'sklearn'
     dataset = helpers.load_custom_testing_dataset_binary()
     d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
     ML_modelpath = helpers.get_custom_dataset_modelpath_pipeline_binary()
     m = dice_ml.Model(model_path=ML_modelpath, backend=backend)
-    exp = dice_ml.Dice(d, m, method='genetic')
+    exp = dice_ml.Dice(d, m, method='random')
     return exp
 
 
 @pytest.fixture
-def genetic_multi_classification_exp_object():
+def random_multi_classification_exp_object():
     backend = 'sklearn'
     dataset = helpers.load_custom_testing_dataset_multiclass()
     d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
     ML_modelpath = helpers.get_custom_dataset_modelpath_pipeline_multiclass()
     m = dice_ml.Model(model_path=ML_modelpath, backend=backend)
-    exp = dice_ml.Dice(d, m, method='genetic')
+    exp = dice_ml.Dice(d, m, method='random')
     return exp
 
 
 @pytest.fixture
-def genetic_regression_exp_object():
+def random_regression_exp_object():
     backend = 'sklearn'
     dataset = helpers.load_custom_testing_dataset_regression()
     d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
     ML_modelpath = helpers.get_custom_dataset_modelpath_pipeline_regression()
     m = dice_ml.Model(model_path=ML_modelpath, backend=backend, model_type='regressor')
-    exp = dice_ml.Dice(d, m, method='genetic')
+    exp = dice_ml.Dice(d, m, method='random')
     return exp
 
 
-class TestDiceGeneticBinaryClassificationMethods:
+class TestDiceRandomBinaryClassificationMethods:
     @pytest.fixture(autouse=True)
-    def _initiate_exp_object(self, genetic_binary_classification_exp_object):
-        self.exp = genetic_binary_classification_exp_object  # explainer object
+    def _initiate_exp_object(self, random_binary_classification_exp_object):
+        self.exp = random_binary_classification_exp_object  # explainer object
 
     # When invalid desired_class is given
     @pytest.mark.parametrize("desired_class, total_CFs", [(7, 3)])
@@ -126,17 +126,6 @@ class TestDiceGeneticBinaryClassificationMethods:
         with pytest.raises(ValueError):
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
 
-    # Testing if only valid cfs are found after maxiterations
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
-                             [(0, 7, "kdtree", 0), (0, 7, "random", 0)])
-    def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert i == desired_class
-
     # Testing for 0 CFs needed
     @pytest.mark.parametrize("desired_class, total_CFs, initialization",
                              [(0, 0, "kdtree"), (0, 0, "random")])
@@ -147,10 +136,10 @@ class TestDiceGeneticBinaryClassificationMethods:
                                            initialization=initialization)
 
 
-class TestDiceGeneticMultiClassificationMethods:
+class TestDiceRandomMultiClassificationMethods:
     @pytest.fixture(autouse=True)
-    def _initiate_exp_object(self, genetic_multi_classification_exp_object):
-        self.exp = genetic_multi_classification_exp_object  # explainer object
+    def _initiate_exp_object(self, random_multi_classification_exp_object):
+        self.exp = random_multi_classification_exp_object  # explainer object
 
     # Testing that the counterfactuals are in the desired class
     @pytest.mark.parametrize("desired_class, total_CFs, initialization", [(2, 2, "kdtree"), (2, 2, "random")])
@@ -160,17 +149,6 @@ class TestDiceGeneticMultiClassificationMethods:
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization)
         assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
-
-    # Testing if only valid cfs are found after maxiterations
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
-                             [(2, 7, "kdtree", 0), (2, 7, "random", 0)])
-    def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert i == desired_class
 
     # Testing for 0 CFs needed
     @pytest.mark.parametrize("desired_class, total_CFs, initialization",
@@ -182,10 +160,10 @@ class TestDiceGeneticMultiClassificationMethods:
                                            initialization=initialization)
 
 
-class TestDiceGeneticRegressionMethods:
+class TestDiceRandomRegressionMethods:
     @pytest.fixture(autouse=True)
-    def _initiate_exp_object(self, genetic_regression_exp_object):
-        self.exp = genetic_regression_exp_object  # explainer object
+    def _initiate_exp_object(self, random_regression_exp_object):
+        self.exp = random_regression_exp_object  # explainer object
 
     # features_range
     @pytest.mark.parametrize("desired_range, total_CFs, initialization",
@@ -198,17 +176,6 @@ class TestDiceGeneticRegressionMethods:
         assert all(
             [desired_range[0]] * total_CFs <= ans.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
             ans.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
-
-    # Testing if only valid cfs are found after maxiterations
-    @pytest.mark.parametrize("desired_range, total_CFs, initialization, maxiterations",
-                             [([1, 2.8], 7, "kdtree", 0), ([1, 2.8], 7, "random", 0)])
-    def test_maxiter(self, desired_range, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_range=desired_range,
-                                                 initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert desired_range[0] <= i <= desired_range[1]
 
     # Testing for 0 CFs needed
     @pytest.mark.parametrize("desired_range, total_CFs, initialization",

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -43,11 +43,14 @@ class TestDiceRandomBinaryClassificationMethods:
         self.exp = random_binary_classification_exp_object  # explainer object
 
     # When invalid desired_class is given
-    @pytest.mark.parametrize("desired_class, total_CFs", [(7, 3)])
-    def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",
+                             [(7, None, 3, "all", None)])
+    def test_no_cfs(self, desired_class, desired_range, sample_custom_query_1, total_CFs, features_to_vary, permitted_range):
         with pytest.raises(UserConfigValidationException):
-            self.exp._generate_counterfactuals(query_instance=sample_custom_query_1, total_CFs=total_CFs,
-                                               desired_class=desired_class)
+            self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_1,
+                                               total_CFs=total_CFs,
+                                               desired_class=desired_class, desired_range=desired_range,
+                                               permitted_range=permitted_range)
 
     # When a query's feature value is not within the permitted range and the feature is not allowed to vary
     @pytest.mark.parametrize("features_to_vary, permitted_range, feature_weights",
@@ -57,57 +60,50 @@ class TestDiceRandomBinaryClassificationMethods:
             self.exp.setup(features_to_vary, permitted_range, sample_custom_query_1, feature_weights)
 
     # # Testing that the counterfactuals are in the desired class
-    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
-                             [(1, 2, "all", "kdtree"), (1, 2, "all", "random")])
-    def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",[(1, None, 2, "all", None)])
+    def test_desired_class(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary, permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
         assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing that the features_to_vary argument actually varies only the features that you wish to vary
-    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
-                             [(1, 2, ["Numerical"], "kdtree"), (1, 2, ["Numerical"], "random")])
-    def test_features_to_vary(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",
+                             [(1, None, 2, ["Numerical"], None)])
+    def test_features_to_vary(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary, permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
 
         for feature in self.exp.data_interface.feature_names:
             if feature not in features_to_vary:
                 assert all(ans.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
                            range(total_CFs))
 
-    # Testing that the permitted_range argument actually varies the features only within the permitted_range
-    @pytest.mark.parametrize("desired_class, total_CFs, permitted_range, initialization",
-                             [(1, 2, {'Numerical': [10, 15]}, "kdtree"), (1, 2, {'Numerical': [10, 15]}, "random")])
-    def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, permitted_range, initialization):
-        features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 features_to_vary=features_to_vary, permitted_range=permitted_range,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
-
-        for feature in permitted_range:
-            assert all(
-                permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
-                in range(total_CFs))
+    # # Testing that the permitted_range argument actually varies the features only within the permitted_range
+    # @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",
+    #                          [(1, None, 2, {'Numerical': [10, 15]})])
+    # def test_permitted_range(self, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+    #     features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
+    #     ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+    #                                              features_to_vary=features_to_vary, permitted_range=permitted_range,
+    #                                              total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range)
+    #
+    #     for feature in permitted_range:
+    #         assert all(
+    #             permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+    #             in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables
-    @pytest.mark.parametrize("desired_class, total_CFs, permitted_range, initialization",
-                             [(1, 2, {'Categorical': ['a', 'c']}, "kdtree"),
-                              (1, 2, {'Categorical': ['a', 'c']}, "random")])
-    def test_permitted_range_categorical(self, desired_class, total_CFs, sample_custom_query_2, permitted_range,
-                                         initialization):
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",
+                             [(1, None, 2, {'Categorical': ['a', 'c']})])
+    def test_permitted_range_categorical(self, desired_class, desired_range, total_CFs, sample_custom_query_2, permitted_range):
         features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range)
 
         for feature in permitted_range:
             assert all(
@@ -127,13 +123,11 @@ class TestDiceRandomBinaryClassificationMethods:
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization",
-                             [(0, 0, "kdtree"), (0, 0, "random")])
-    def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class,
-                                           initialization=initialization)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range", [("all", 0, None, 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
+        self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
+                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
 
 
 class TestDiceRandomMultiClassificationMethods:
@@ -142,22 +136,18 @@ class TestDiceRandomMultiClassificationMethods:
         self.exp = random_multi_classification_exp_object  # explainer object
 
     # Testing that the counterfactuals are in the desired class
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization", [(2, 2, "kdtree"), (2, 2, "random")])
-    def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range", [("all", 2, None, 2, None)])
+    def test_desired_class(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
+        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
+                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
         assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization",
-                             [(2, 0, "kdtree"), (2, 0, "random")])
-    def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class,
-                                           initialization=initialization)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", 2, None, 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
+                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
 
 
 class TestDiceRandomRegressionMethods:
@@ -166,22 +156,16 @@ class TestDiceRandomRegressionMethods:
         self.exp = random_regression_exp_object  # explainer object
 
     # features_range
-    @pytest.mark.parametrize("desired_range, total_CFs, initialization",
-                             [([1, 2.8], 2, "kdtree"), ([1, 2.8], 2, "random")])
-    def test_desired_range(self, desired_range, sample_custom_query_2, total_CFs, initialization):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_range=desired_range,
-                                                 initialization=initialization)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", None, [1, 2.8], 2, None)])
+    def test_desired_range(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
+                                                 total_CFs=total_CFs, desired_class= desired_class, desired_range=desired_range, permitted_range=permitted_range)
         assert all(
             [desired_range[0]] * total_CFs <= ans.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
             ans.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_range, total_CFs, initialization",
-                             [([1, 2.8], 0, "kdtree"), ([1, 2.8], 0, "random")])
-    def test_zero_cfs(self, desired_range, sample_custom_query_2, total_CFs, initialization):
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_range=desired_range,
-                                           initialization=initialization)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", None, [1, 2.8], 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
+                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -88,20 +88,22 @@ class TestDiceRandomBinaryClassificationMethods:
                 assert all(ans.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
                            range(total_CFs))
 
-    # # Testing that the permitted_range argument actually varies the features only within the permitted_range
-    # @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",
-    #                          [(1, None, 2, {'Numerical': [10, 15]})])
-    # def test_permitted_range(self, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
-    #     features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
-    #     ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-    #                                              features_to_vary=features_to_vary, permitted_range=permitted_range,
-    #                                              total_CFs=total_CFs, desired_class=desired_class,
-    #                                              desired_range=desired_range)
-    #
-    #     for feature in permitted_range:
-    #         assert all(
-    #           permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
-    #             in range(total_CFs))
+    @pytest.mark.skip(reason="Currently, dice_random doesn't support permitted_range. Please un-skip this test once "
+                             "that functionality is implemented.")
+    # Testing that the permitted_range argument actually varies the features only within the permitted_range
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",
+                             [(1, None, 2, {'Numerical': [10, 15]})])
+    def test_permitted_range(self, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+        features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
+        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+                                                 features_to_vary=features_to_vary, permitted_range=permitted_range,
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range)
+
+        for feature in permitted_range:
+            assert all(
+              permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables
     @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -45,7 +45,8 @@ class TestDiceRandomBinaryClassificationMethods:
     # When invalid desired_class is given
     @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",
                              [(7, None, 3, "all", None)])
-    def test_no_cfs(self, desired_class, desired_range, sample_custom_query_1, total_CFs, features_to_vary, permitted_range):
+    def test_no_cfs(self, desired_class, desired_range, sample_custom_query_1, total_CFs, features_to_vary,
+                    permitted_range):
         with pytest.raises(UserConfigValidationException):
             self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_1,
                                                total_CFs=total_CFs,
@@ -60,22 +61,27 @@ class TestDiceRandomBinaryClassificationMethods:
             self.exp.setup(features_to_vary, permitted_range, sample_custom_query_1, feature_weights)
 
     # # Testing that the counterfactuals are in the desired class
-    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",[(1, None, 2, "all", None)])
-    def test_desired_class(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary, permitted_range):
+    @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",
+                             [(1, None, 2, "all", None)])
+    def test_desired_class(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary,
+                           permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range, permitted_range=permitted_range)
         assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing that the features_to_vary argument actually varies only the features that you wish to vary
     @pytest.mark.parametrize("desired_class, desired_range, total_CFs, features_to_vary, permitted_range",
                              [(1, None, 2, ["Numerical"], None)])
-    def test_features_to_vary(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary, permitted_range):
+    def test_features_to_vary(self, desired_class, desired_range, sample_custom_query_2, total_CFs, features_to_vary,
+                              permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range, permitted_range=permitted_range)
 
         for feature in self.exp.data_interface.feature_names:
             if feature not in features_to_vary:
@@ -99,11 +105,13 @@ class TestDiceRandomBinaryClassificationMethods:
     # Testing if you can provide permitted_range for categorical variables
     @pytest.mark.parametrize("desired_class, desired_range, total_CFs, permitted_range",
                              [(1, None, 2, {'Categorical': ['a', 'c']})])
-    def test_permitted_range_categorical(self, desired_class, desired_range, total_CFs, sample_custom_query_2, permitted_range):
+    def test_permitted_range_categorical(self, desired_class, desired_range, total_CFs, sample_custom_query_2,
+                                         permitted_range):
         features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
-                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range)
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range)
 
         for feature in permitted_range:
             assert all(
@@ -123,11 +131,14 @@ class TestDiceRandomBinaryClassificationMethods:
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range", [("all", 0, None, 0, None)])
-    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",
+                             [("all", 0, None, 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs,
+                      permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+                                           total_CFs=total_CFs, desired_class=desired_class,
+                                           desired_range=desired_range, permitted_range=permitted_range)
 
 
 class TestDiceRandomMultiClassificationMethods:
@@ -136,18 +147,25 @@ class TestDiceRandomMultiClassificationMethods:
         self.exp = random_multi_classification_exp_object  # explainer object
 
     # Testing that the counterfactuals are in the desired class
-    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range", [("all", 2, None, 2, None)])
-    def test_desired_class(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",
+                             [("all", 2, None, 2, None)])
+    def test_desired_class(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs,
+                           permitted_range):
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary,
+                                                 query_instance=sample_custom_query_2,
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range, permitted_range=permitted_range)
         assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", 2, None, 0, None)])
-    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",
+                             [("all", 2, None, 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs,
+                      permitted_range):
         self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+                                           total_CFs=total_CFs, desired_class=desired_class,
+                                           desired_range=desired_range, permitted_range=permitted_range)
 
 
 class TestDiceRandomRegressionMethods:
@@ -156,16 +174,23 @@ class TestDiceRandomRegressionMethods:
         self.exp = random_regression_exp_object  # explainer object
 
     # features_range
-    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", None, [1, 2.8], 2, None)])
-    def test_desired_range(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
-        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class= desired_class, desired_range=desired_range, permitted_range=permitted_range)
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",
+                             [("all", None, [1, 2.8], 2, None)])
+    def test_desired_range(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs,
+                           permitted_range):
+        ans = self.exp._generate_counterfactuals(features_to_vary=features_to_vary,
+                                                 query_instance=sample_custom_query_2,
+                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                 desired_range=desired_range, permitted_range=permitted_range)
         assert all(
             [desired_range[0]] * total_CFs <= ans.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
             ans.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
 
     # Testing for 0 CFs needed
-    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",[("all", None, [1, 2.8], 0, None)])
-    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs, permitted_range):
+    @pytest.mark.parametrize("features_to_vary, desired_class, desired_range, total_CFs, permitted_range",
+                             [("all", None, [1, 2.8], 0, None)])
+    def test_zero_cfs(self, features_to_vary, desired_class, desired_range, sample_custom_query_2, total_CFs,
+                      permitted_range):
         self.exp._generate_counterfactuals(features_to_vary=features_to_vary, query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range, permitted_range=permitted_range)
+                                           total_CFs=total_CFs, desired_class=desired_class,
+                                           desired_range=desired_range, permitted_range=permitted_range)

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -95,11 +95,12 @@ class TestDiceRandomBinaryClassificationMethods:
     #     features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
     #     ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
     #                                              features_to_vary=features_to_vary, permitted_range=permitted_range,
-    #                                              total_CFs=total_CFs, desired_class=desired_class, desired_range=desired_range)
+    #                                              total_CFs=total_CFs, desired_class=desired_class,
+    #                                              desired_range=desired_range)
     #
     #     for feature in permitted_range:
     #         assert all(
-    #             permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+    #           permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
     #             in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables


### PR DESCRIPTION
In response to #161 
- Added check to throw an error if query instance has an unknown column
- Added tests for dice_genetic, dice_KD to check if query instance has an unknown column
- Fixed bug in helpers.py - added parameter invalid_raise = True for the adult dataset
- Fixed bug in tests: query instance had categorical values not present in training data
- Added tests for dice_random