### PR TITLE
Create copy of dataframe in public_data_interface.py to avoid user data corruption

### DIFF
--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -96,7 +96,7 @@ class PublicData(_BaseData):
             raise ValueError("dataframe not found in params")
 
         if isinstance(params['dataframe'], pd.DataFrame):
-            self.data_df = params['dataframe']
+            self.data_df = params['dataframe'].copy()
         else:
             raise ValueError("should provide a pandas dataframe")
 

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn.datasets import load_iris
 
@@ -165,3 +166,14 @@ class TestErrorCasesPublicDataInterface:
 
         assert "continuous_features_precision contains some feature names which" + \
             " are not part of columns in dataframe" in str(ucve)
+
+
+class TestUserDataCorruption:
+
+    def test_user_data_corruption(self):
+        dataset = helpers.load_adult_income_dataset()
+        dataset_copy = dataset.copy()
+        dice_ml.Data(dataframe=dataset, continuous_features=['age', 'hours_per_week'],
+                     outcome_name='income', permitted_range={'age': [45, 60]},
+                     continuous_features_precision={'hours_per_week': 2})
+        pd.testing.assert_frame_equal(dataset, dataset_copy)


### PR DESCRIPTION
It seems like the user dataframe is corrupted as public_data_interface.py tries to change the metdata in case of categorical columns. The fix is to make a copy of data and use the copy throughout the data interface. 

Signed-off-by: gaugup <gaugup@microsoft.com>