### PR TITLE
Add validation to check target column in query instance

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -139,6 +139,8 @@ class ExplainerBase(ABC):
         pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
+        # import pdb
+        # pdb.set_trace()
         if features_to_vary == 'all':
             features_to_vary = self.data_interface.feature_names
 
@@ -156,6 +158,10 @@ class ExplainerBase(ABC):
 
     def check_query_instance_validity(self, features_to_vary, permitted_range, query_instance, feature_ranges_orig):
         for feature in query_instance:
+            print(feature)
+            if feature == self.data_interface.outcome_name:
+                raise ValueError("Target", self.data_interface.outcome_name, "present in query instance")
+
             if feature not in self.data_interface.feature_names:
                 raise ValueError("Feature", feature, "not present in training data!")
 

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -139,8 +139,6 @@ class ExplainerBase(ABC):
         pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
-        # import pdb
-        # pdb.set_trace()
         if features_to_vary == 'all':
             features_to_vary = self.data_interface.feature_names
 
@@ -158,7 +156,6 @@ class ExplainerBase(ABC):
 
     def check_query_instance_validity(self, features_to_vary, permitted_range, query_instance, feature_ranges_orig):
         for feature in query_instance:
-            print(feature)
             if feature == self.data_interface.outcome_name:
                 raise ValueError("Target", self.data_interface.outcome_name, "present in query instance")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,14 @@ def sample_custom_query_3():
 
 
 @pytest.fixture
+def sample_custom_query_4():
+    """
+    Returns a sample query instance for the custom dataset
+    """
+    return pd.DataFrame({'Categorical': ['c'], 'Numerical': [13]})
+
+
+@pytest.fixture
 def sample_custom_query_5():
     """
     Returns a sample query instance for the custom dataset
@@ -111,11 +119,11 @@ def sample_custom_query_5():
 
 
 @pytest.fixture
-def sample_custom_query_4():
+def sample_custom_query_6():
     """
-    Returns a sample query instance for the custom dataset
+    Returns a sample query instance for the custom dataset including Outcome
     """
-    return pd.DataFrame({'Categorical': ['c'], 'Numerical': [13]})
+    return pd.DataFrame({'Categorical': ['c'], 'Numerical': [13], 'Outcome': 0})
 
 
 @pytest.fixture

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -121,10 +121,16 @@ class TestDiceGeneticBinaryClassificationMethods:
             self.exp.setup("all", None, sample_custom_query_3, "inverse_mad")
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
-    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs):
+    def test_query_instance_unknown_column(self, sample_custom_query_5):
         with pytest.raises(ValueError):
             self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
+
+    # Testing if an error is thrown when the query instance has outcome variable
+    def test_query_instance_with_target_column(self, sample_custom_query_6):
+        with pytest.raises(ValueError) as ve:
+            self.exp.setup("all", None, sample_custom_query_6, "inverse_mad")
+
+        assert "present in query instance" in str(ve)
 
     # Testing if only valid cfs are found after maxiterations
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",


### PR DESCRIPTION
- Alerting users when they look to generate counterfactuals that they don't have target in their query instances.
-  
Signed-off-by: gaugup <gaugup@microsoft.com>