### PR TITLE
Returning original index for dice-KD

### DIFF
--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -114,7 +114,7 @@ class CounterfactualExamples:
                         newdf[ix][jx] = '-'
                     else:
                         newdf[ix][jx] = str(newdf[ix][jx])
-            display(pd.DataFrame(newdf, columns=df.columns))  # works only in Jupyter notebook
+            display(pd.DataFrame(newdf, columns=df.columns, index=df.index))  # works only in Jupyter notebook
 
     def visualize_as_list(self, display_sparse_df=True, show_only_changes=False):
         # original instance

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -177,7 +177,6 @@ class DiceKD(ExplainerBase):
 
         # Iterating through the closest points from the KD tree and checking if any of these are valid
         if self.KD_tree is not None and total_CFs > 0:
-            cfs = cfs.reset_index(drop=True)
             for i in range(len(cfs)):
                 if total_cfs_found == total_CFs:
                     break

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -134,22 +134,26 @@ class DiceRandom(ExplainerBase):
             cfs_df.reset_index(inplace=True, drop=True)
             if len(cfs_df) > 0:
                 self.cfs_pred_scores = self.predict_fn(cfs_df)
+                cfs_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.cfs_pred_scores)
             else:
                 if self.model.model_type == ModelTypes.Classifier:
                     self.cfs_pred_scores = [0]*self.num_output_nodes
                 else:
                     self.cfs_pred_scores = [0]
-            cfs_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.cfs_pred_scores)
-
             self.total_cfs_found = len(cfs_df)
 
             self.valid_cfs_found = True if self.total_cfs_found >= self.total_CFs else False
-
-            final_cfs_df = cfs_df[self.data_interface.feature_names + [self.data_interface.outcome_name]]
-            final_cfs_df[self.data_interface.outcome_name] = \
-                final_cfs_df[self.data_interface.outcome_name].round(self.outcome_precision)
-            self.cfs_preds = final_cfs_df[[self.data_interface.outcome_name]].values
-            self.final_cfs = final_cfs_df[self.data_interface.feature_names].values
+            if len(cfs_df) > 0:
+                final_cfs_df = cfs_df[self.data_interface.feature_names + [self.data_interface.outcome_name]]
+                final_cfs_df[self.data_interface.outcome_name] = \
+                    final_cfs_df[self.data_interface.outcome_name].round(self.outcome_precision)
+                self.cfs_preds = final_cfs_df[[self.data_interface.outcome_name]].values
+                self.final_cfs = final_cfs_df[self.data_interface.feature_names].values
+            else:
+                final_cfs_df = None
+                self.cfs_preds = None
+                self.cfs_pred_scores = None
+                self.final_cfs = None
         else:
             final_cfs_df = None
             self.cfs_preds = None

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -395,7 +395,7 @@ class ExplainerBase(ABC):
             for feature in features_sorted:
                 # current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iat[[cf_ix]][self.data_interface.feature_names])
                 # feat_ix = self.data_interface.continuous_feature_names.index(feature)
-                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
+                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.at[cf_ix, feature])
                 if(abs(diff) <= quantiles[feature]):
                     if posthoc_sparsity_algorithm == "linear":
                         final_cfs_sparse = self.do_linear_search(diff, decimal_prec, query_instance, cf_ix,
@@ -421,17 +421,17 @@ class ExplainerBase(ABC):
         current_pred = current_pred_orig
         if self.model.model_type == ModelTypes.Classifier:
             while((abs(diff) > 10e-4) and (np.sign(diff*old_diff) > 0) and self.is_cf_valid(current_pred)):
-                old_val = int(final_cfs_sparse.loc[[cf_ix]][feature])
-                final_cfs_sparse.loc[cf_ix, feature] += np.sign(diff)*change
+                old_val = int(final_cfs_sparse.at[cf_ix, feature])
+                final_cfs_sparse.at[cf_ix, feature] += np.sign(diff)*change
                 current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
                 old_diff = diff
 
                 if not self.is_cf_valid(current_pred):
-                    final_cfs_sparse.loc[cf_ix, feature] = old_val
-                    diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
+                    final_cfs_sparse.at[cf_ix, feature] = old_val
+                    diff = query_instance[feature].iat[0] - int(final_cfs_sparse.at[cf_ix, feature])
                     return final_cfs_sparse
 
-                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
+                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.at[cf_ix, feature])
 
         return final_cfs_sparse
 
@@ -439,8 +439,8 @@ class ExplainerBase(ABC):
         """Performs a binary search between continuous features of a CF and corresponding values
            in query_instance until the prediction class changes."""
 
-        old_val = int(final_cfs_sparse.loc[[cf_ix]][feature])
-        final_cfs_sparse.loc[cf_ix, feature] = query_instance[feature].iat[0]
+        old_val = int(final_cfs_sparse.at[cf_ix, feature])
+        final_cfs_sparse.at[cf_ix, feature] = query_instance[feature].iat[0]
         # Prediction of the query instance
         current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
@@ -448,18 +448,18 @@ class ExplainerBase(ABC):
         if self.is_cf_valid(current_pred):
             return final_cfs_sparse
         else:
-            final_cfs_sparse.loc[cf_ix, feature] = old_val
+            final_cfs_sparse.at[cf_ix, feature] = old_val
 
         # move the CF values towards the query_instance
         if diff > 0:
-            left = int(final_cfs_sparse.loc[[cf_ix]][feature])
+            left = int(final_cfs_sparse.at[cf_ix, feature])
             right = query_instance[feature].iat[0]
 
             while left <= right:
                 current_val = left + ((right - left)/2)
                 current_val = round(current_val, decimal_prec[feature])
 
-                final_cfs_sparse.loc[cf_ix, feature] = current_val
+                final_cfs_sparse.at[cf_ix, feature] = current_val
                 current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
                 if current_val == right or current_val == left:
@@ -472,13 +472,13 @@ class ExplainerBase(ABC):
 
         else:
             left = query_instance[feature].iat[0]
-            right = int(final_cfs_sparse.loc[[cf_ix]][feature])
+            right = int(final_cfs_sparse.at[cf_ix, feature])
 
             while right >= left:
                 current_val = right - ((right - left)/2)
                 current_val = round(current_val, decimal_prec[feature])
 
-                final_cfs_sparse.loc[cf_ix, feature] = current_val
+                final_cfs_sparse.at[cf_ix, feature] = current_val
                 current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
                 if current_val == right or current_val == left:

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -372,8 +372,6 @@ class ExplainerBase(ABC):
         if final_cfs_sparse is None:
             return final_cfs_sparse
 
-        # resetting index to make sure .loc works
-        final_cfs_sparse = final_cfs_sparse.reset_index(drop=True)
         # quantiles of the deviation from median for every continuous feature
         quantiles = self.data_interface.get_quantiles_from_training_data(quantile=posthoc_sparsity_param)
         mads = self.data_interface.get_valid_mads()
@@ -392,14 +390,13 @@ class ExplainerBase(ABC):
 
         cfs_preds_sparse = []
 
-        for cf_ix in range(len(final_cfs_sparse)):
-            current_pred = self.predict_fn_for_sparsity(
-                final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+        for cf_ix in list(final_cfs_sparse.index):
+            current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
             for feature in features_sorted:
                 # current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iat[[cf_ix]][self.data_interface.feature_names])
                 # feat_ix = self.data_interface.continuous_feature_names.index(feature)
-                diff = query_instance[feature].iat[0] - final_cfs_sparse[feature].iat[cf_ix]
-                if abs(diff) <= quantiles[feature]:
+                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
+                if(abs(diff) <= quantiles[feature]):
                     if posthoc_sparsity_algorithm == "linear":
                         final_cfs_sparse = self.do_linear_search(diff, decimal_prec, query_instance, cf_ix,
                                                                  feature, final_cfs_sparse, current_pred)
@@ -408,7 +405,7 @@ class ExplainerBase(ABC):
                         final_cfs_sparse = self.do_binary_search(
                             diff, decimal_prec, query_instance, cf_ix, feature, final_cfs_sparse, current_pred)
 
-            temp_preds = self.predict_fn_for_sparsity(final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+            temp_preds = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
             cfs_preds_sparse.append(temp_preds)
 
         final_cfs_sparse[self.data_interface.outcome_name] = self.get_model_output_from_scores(cfs_preds_sparse)
@@ -424,17 +421,17 @@ class ExplainerBase(ABC):
         current_pred = current_pred_orig
         if self.model.model_type == ModelTypes.Classifier:
             while((abs(diff) > 10e-4) and (np.sign(diff*old_diff) > 0) and self.is_cf_valid(current_pred)):
-                old_val = final_cfs_sparse[feature].iat[cf_ix]
+                old_val = int(final_cfs_sparse.loc[[cf_ix]][feature])
                 final_cfs_sparse.loc[cf_ix, feature] += np.sign(diff)*change
-                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
                 old_diff = diff
 
                 if not self.is_cf_valid(current_pred):
                     final_cfs_sparse.loc[cf_ix, feature] = old_val
-                    diff = query_instance[feature].iat[0] - final_cfs_sparse[feature].iat[cf_ix]
+                    diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
                     return final_cfs_sparse
 
-                diff = query_instance[feature].iat[0] - final_cfs_sparse[feature].iat[cf_ix]
+                diff = query_instance[feature].iat[0] - int(final_cfs_sparse.loc[[cf_ix]][feature])
 
         return final_cfs_sparse
 
@@ -442,10 +439,10 @@ class ExplainerBase(ABC):
         """Performs a binary search between continuous features of a CF and corresponding values
            in query_instance until the prediction class changes."""
 
-        old_val = final_cfs_sparse[feature].iat[cf_ix]
+        old_val = int(final_cfs_sparse.loc[[cf_ix]][feature])
         final_cfs_sparse.loc[cf_ix, feature] = query_instance[feature].iat[0]
         # Prediction of the query instance
-        current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+        current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
         # first check if assigning query_instance values to a CF is required.
         if self.is_cf_valid(current_pred):
@@ -455,7 +452,7 @@ class ExplainerBase(ABC):
 
         # move the CF values towards the query_instance
         if diff > 0:
-            left = final_cfs_sparse[feature].iat[cf_ix]
+            left = int(final_cfs_sparse.loc[[cf_ix]][feature])
             right = query_instance[feature].iat[0]
 
             while left <= right:
@@ -463,7 +460,7 @@ class ExplainerBase(ABC):
                 current_val = round(current_val, decimal_prec[feature])
 
                 final_cfs_sparse.loc[cf_ix, feature] = current_val
-                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
                 if current_val == right or current_val == left:
                     break
@@ -475,14 +472,14 @@ class ExplainerBase(ABC):
 
         else:
             left = query_instance[feature].iat[0]
-            right = final_cfs_sparse[feature].iat[cf_ix]
+            right = int(final_cfs_sparse.loc[[cf_ix]][feature])
 
             while right >= left:
                 current_val = right - ((right - left)/2)
                 current_val = round(current_val, decimal_prec[feature])
 
                 final_cfs_sparse.loc[cf_ix, feature] = current_val
-                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.iloc[[cf_ix]][self.data_interface.feature_names])
+                current_pred = self.predict_fn_for_sparsity(final_cfs_sparse.loc[[cf_ix]][self.data_interface.feature_names])
 
                 if current_val == right or current_val == left:
                     break

--- a/docs/source/notebooks/DiCE_model_agnostic_CFs.ipynb
+++ b/docs/source/notebooks/DiCE_model_agnostic_CFs.ipynb
@@ -557,7 +557,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.8.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,13 @@ def sample_custom_query_4():
     """
     return pd.DataFrame({'Categorical': ['c'], 'Numerical': [13]})
 
+@pytest.fixture
+def sample_custom_query_index():
+    """
+    Returns a sample query instance for the custom dataset
+    """
+    return pd.DataFrame({'Categorical': ['a'], 'Numerical': [88]})
+
 
 @pytest.fixture
 def sample_custom_query_10():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def sample_custom_query_4():
     """
     return pd.DataFrame({'Categorical': ['c'], 'Numerical': [13]})
 
+
 @pytest.fixture
 def sample_custom_query_index():
     """

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -153,6 +153,14 @@ class TestDiceKDBinaryClassificationMethods:
         self.exp._generate_counterfactuals(query_instance=sample_custom_query_4, total_CFs=total_CFs,
                                            desired_class=desired_class)
 
+    # Testing for index returned
+    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
+    @pytest.mark.parametrize('posthoc_sparsity_algorithm', ['linear', 'binary', None])
+    def test_zero_cfs(self, desired_class, sample_custom_query_index, total_CFs, posthoc_sparsity_algorithm):
+        self.exp._generate_counterfactuals(query_instance=sample_custom_query_index, total_CFs=total_CFs,
+                                           desired_class=desired_class,
+                                           posthoc_sparsity_algorithm=posthoc_sparsity_algorithm)
+        assert self.exp.final_cfs_df.index[0] == 3
 
 class TestDiceKDMultiClassificationMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -156,11 +156,12 @@ class TestDiceKDBinaryClassificationMethods:
     # Testing for index returned
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
     @pytest.mark.parametrize('posthoc_sparsity_algorithm', ['linear', 'binary', None])
-    def test_zero_cfs(self, desired_class, sample_custom_query_index, total_CFs, posthoc_sparsity_algorithm):
+    def test_index(self, desired_class, sample_custom_query_index, total_CFs, posthoc_sparsity_algorithm):
         self.exp._generate_counterfactuals(query_instance=sample_custom_query_index, total_CFs=total_CFs,
                                            desired_class=desired_class,
                                            posthoc_sparsity_algorithm=posthoc_sparsity_algorithm)
         assert self.exp.final_cfs_df.index[0] == 3
+
 
 class TestDiceKDMultiClassificationMethods:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Signed-off-by: Soundarya Krishnan <soundaryak4898@gmail.com>
In response to issue #169 
- Made changes to show original indices of rows in the training data while displaying counterfactuals
- Added a test to ensure that this logic is being followed
- Fixed bug in dice_random when 0 cfs were being returned