### PR TITLE
Fixed bugs for issue 168

### DIFF
--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -22,6 +22,10 @@ class _BaseData(ABC):
         else:
             raise ValueError("should provide the name of outcome feature as a string")
 
+    def _validate_outcome_as_last_column(self):
+        if self.data_df.columns.get_loc(self.outcome_name) != len(self.data_df.columns) - 1:
+            raise ValueError("Outcome should be the last column! Please reorder!")
+
     @abstractmethod
     def __init__(self, params):
         """The init method needs to be implemented by the inherting classes."""

--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -22,10 +22,6 @@ class _BaseData(ABC):
         else:
             raise ValueError("should provide the name of outcome feature as a string")
 
-    def _validate_outcome_as_last_column(self):
-        if self.data_df.columns.get_loc(self.outcome_name) != len(self.data_df.columns) - 1:
-            raise ValueError("Outcome should be the last column! Please reorder!")
-
     @abstractmethod
     def __init__(self, params):
         """The init method needs to be implemented by the inherting classes."""

--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -22,6 +22,11 @@ class _BaseData(ABC):
         else:
             raise ValueError("should provide the name of outcome feature as a string")
 
+    def set_continuous_feature_indexes(self, query_instance):
+        """Remaps continuous feature indices based on the query instance"""
+        self.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
+                                           self.continuous_feature_names]
+
     @abstractmethod
     def __init__(self, params):
         """The init method needs to be implemented by the inherting classes."""

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -29,7 +29,6 @@ class PublicData(_BaseData):
         self._validate_and_set_outcome_name(params=params)
         self._validate_and_set_dataframe(params=params)
         self._validate_and_set_continuous_features(params=params)
-        # self._validate_outcome_as_last_column()
 
         self.feature_names = [
             name for name in self.data_df.columns.tolist() if name != self.outcome_name]

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -115,11 +115,6 @@ class PublicData(_BaseData):
             raise ValueError(
                 "should provide the name(s) of continuous features in the data as a list")
 
-    def set_continuous_feature_indexes(self, query_instance):
-        """Remaps continuous feature indices based on the query instance"""
-        self.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
-                                           self.continuous_feature_names]
-
     def _validate_and_set_continuous_features_precision(self, params):
         """Validate and set the dictionary of precision for continuous features."""
         if 'continuous_features_precision' in params:

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -29,6 +29,7 @@ class PublicData(_BaseData):
         self._validate_and_set_outcome_name(params=params)
         self._validate_and_set_dataframe(params=params)
         self._validate_and_set_continuous_features(params=params)
+        self._validate_outcome_as_last_column()
 
         self.feature_names = [
             name for name in self.data_df.columns.tolist() if name != self.outcome_name]
@@ -185,7 +186,10 @@ class PublicData(_BaseData):
             for feature_name in self.continuous_feature_names:
                 max_value = self.data_df[feature_name].max()
                 min_value = self.data_df[feature_name].min()
-                result[feature_name] = (df[feature_name] - min_value) / (max_value - min_value)
+                if min_value == max_value:
+                    result[feature_name] = 0
+                else:
+                    result[feature_name] = (df[feature_name] - min_value) / (max_value - min_value)
         else:
             result = result.astype('float')
             for feature_index in self.continuous_feature_indexes:

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -115,6 +115,11 @@ class PublicData(_BaseData):
             raise ValueError(
                 "should provide the name(s) of continuous features in the data as a list")
 
+    def set_continuous_feature_indexes(self, query_instance):
+        """Remaps continuous feature indices based on the query instance"""
+        self.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
+                                                          self.continuous_feature_names]
+
     def _validate_and_set_continuous_features_precision(self, params):
         """Validate and set the dictionary of precision for continuous features."""
         if 'continuous_features_precision' in params:

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -44,9 +44,6 @@ class PublicData(_BaseData):
         self.categorical_feature_names = [name for name in self.data_df.columns.tolist(
         ) if name not in self.continuous_feature_names + [self.outcome_name]]
 
-        self.continuous_feature_indexes = [self.data_df.columns.get_loc(
-            name) for name in self.continuous_feature_names if name in self.data_df]
-
         self.categorical_feature_indexes = [self.data_df.columns.get_loc(
             name) for name in self.categorical_feature_names if name in self.data_df]
 

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -118,7 +118,7 @@ class PublicData(_BaseData):
     def set_continuous_feature_indexes(self, query_instance):
         """Remaps continuous feature indices based on the query instance"""
         self.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
-                                                          self.continuous_feature_names]
+                                           self.continuous_feature_names]
 
     def _validate_and_set_continuous_features_precision(self, params):
         """Validate and set the dictionary of precision for continuous features."""

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -29,7 +29,7 @@ class PublicData(_BaseData):
         self._validate_and_set_outcome_name(params=params)
         self._validate_and_set_dataframe(params=params)
         self._validate_and_set_continuous_features(params=params)
-        self._validate_outcome_as_last_column()
+        # self._validate_outcome_as_last_column()
 
         self.feature_names = [
             name for name in self.data_df.columns.tolist() if name != self.outcome_name]

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -193,10 +193,16 @@ class PublicData(_BaseData):
                 max_value = self.data_df[feature_name].max()
                 min_value = self.data_df[feature_name].min()
                 if len(df.shape) == 1:
-                    value = (df[feature_index] - min_value) / (max_value - min_value)
+                    if min_value == max_value:
+                        value = 0
+                    else:
+                        value = (df[feature_index] - min_value) / (max_value - min_value)
                     result[feature_index] = value
                 else:
-                    result[:, feature_index] = (df[:, feature_index] - min_value) / (max_value - min_value)
+                    if min_value == max_value:
+                        result[:, feature_index] = np.zeros(len(df[:, feature_index]))
+                    else:
+                        result[:, feature_index] = (df[:, feature_index] - min_value) / (max_value - min_value)
         return result
 
     def de_normalize_data(self, df):

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -480,7 +480,7 @@ class DiceGenetic(ExplainerBase):
             predictions = self.predict_fn_scores(population[i])[0]
             if self.is_cf_valid(predictions):
                 self.final_cfs.append(population[i])
-                if not isinstance(predictions, float) and len(predictions) > 1:
+                if not isinstance(predictions, float) and not isinstance(predictions, np.float32) and len(predictions) > 1:
                     self.cfs_preds.append(np.argmax(predictions))
                 else:
                     self.cfs_preds.append(predictions)

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -264,9 +264,6 @@ class DiceGenetic(ExplainerBase):
 
         features_to_vary = self.setup(features_to_vary, permitted_range, query_instance, feature_weights)
 
-        # Remaps continuous feature indices based on the query instance
-        self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in self.data_interface.continuous_feature_names]
-
         # Prepares user defined query_instance for DiCE.
         query_instance_orig = query_instance
         query_instance = self.data_interface.prepare_query_instance(query_instance=query_instance)

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -480,7 +480,10 @@ class DiceGenetic(ExplainerBase):
             predictions = self.predict_fn_scores(population[i])[0]
             if self.is_cf_valid(predictions):
                 self.final_cfs.append(population[i])
-                if not isinstance(predictions, float) and not isinstance(predictions, np.float32) and len(predictions) > 1:
+                # checking if predictions is a float before taking the length as len() works only for array-like
+                # elements. isinstance(predictions, (np.floating, float)) checks if it's any float (numpy or otherwise)
+                # We do this as we take the argmax if the prediction is a vector -- like the output of a classifier
+                if not isinstance(predictions, (np.floating, float)) and len(predictions) > 1:
                     self.cfs_preds.append(np.argmax(predictions))
                 else:
                     self.cfs_preds.append(predictions)

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -264,6 +264,9 @@ class DiceGenetic(ExplainerBase):
 
         features_to_vary = self.setup(features_to_vary, permitted_range, query_instance, feature_weights)
 
+        # Remaps continuous feature indices based on the query instance
+        self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in self.data_interface.continuous_feature_names]
+
         # Prepares user defined query_instance for DiCE.
         query_instance_orig = query_instance
         query_instance = self.data_interface.prepare_query_instance(query_instance=query_instance)

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -88,9 +88,7 @@ class ExplainerBase(ABC):
         elif isinstance(query_instances, Iterable):
             query_instances_list = query_instances
         for query_instance in tqdm(query_instances_list):
-            # Remaps continuous feature indices based on the query instance
-            self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
-                                                              self.data_interface.continuous_feature_names]
+            self.data_interface.set_continuous_feature_indexes(query_instance)
             res = self._generate_counterfactuals(
                 query_instance, total_CFs,
                 desired_class=desired_class,
@@ -142,8 +140,6 @@ class ExplainerBase(ABC):
         pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
-        self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
-                                                          self.data_interface.continuous_feature_names]
         if features_to_vary == 'all':
             features_to_vary = self.data_interface.feature_names
 

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -142,6 +142,8 @@ class ExplainerBase(ABC):
         pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
+        self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
+                                                          self.data_interface.continuous_feature_names]
         if features_to_vary == 'all':
             features_to_vary = self.data_interface.feature_names
 

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -88,6 +88,9 @@ class ExplainerBase(ABC):
         elif isinstance(query_instances, Iterable):
             query_instances_list = query_instances
         for query_instance in tqdm(query_instances_list):
+            # Remaps continuous feature indices based on the query instance
+            self.data_interface.continuous_feature_indexes = [query_instance.columns.get_loc(name) for name in
+                                                              self.data_interface.continuous_feature_names]
             res = self._generate_counterfactuals(
                 query_instance, total_CFs,
                 desired_class=desired_class,

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -89,13 +89,16 @@ def load_custom_testing_dataset():
     data = [['a', 10, 0], ['b', 10000, 0], ['c', 14, 0], ['a', 88, 0], ['c', 14, 0]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
+
 def load_min_max_equal_dataset():
     data = [['a', 10, 0], ['b', 10, 0], ['c', 10, 0], ['a', 10, 0], ['c', 10, 0]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
+
 def load_outcome_not_last_column_dataset():
     data = [['a', 0, 10], ['a', 0, 10000], ['a', 0, 14], ['a', 0, 10], ['a', 0, 10]]
     return pd.DataFrame(data, columns=['Categorical', 'Outcome', 'Numerical'])
+
 
 def load_custom_testing_dataset_binary():
     data = [['a', 1, 0], ['b', 5, 1], ['c', 2, 0], ['a', 3, 0], ['c', 4, 1]]

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -89,6 +89,13 @@ def load_custom_testing_dataset():
     data = [['a', 10, 0], ['b', 10000, 0], ['c', 14, 0], ['a', 88, 0], ['c', 14, 0]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
+def load_min_max_equal_dataset():
+    data = [['a', 10, 0], ['b', 10, 0], ['c', 10, 0], ['a', 10, 0], ['c', 10, 0]]
+    return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
+
+def load_outcome_not_last_column_dataset():
+    data = [['a', 0, 10], ['a', 0, 10000], ['a', 0, 14], ['a', 0, 10], ['a', 0, 10]]
+    return pd.DataFrame(data, columns=['Categorical', 'Outcome', 'Numerical'])
 
 def load_custom_testing_dataset_binary():
     data = [['a', 1, 0], ['b', 5, 1], ['c', 2, 0], ['a', 3, 0], ['c', 4, 1]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def binary_classification_exp_object_out_of_order(method="random"):
     exp = dice_ml.Dice(d, m, method=method)
     return exp
 
+
 @pytest.fixture
 def multi_classification_exp_object(method="random"):
     backend = 'sklearn'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def binary_classification_exp_object(method="random"):
     exp = dice_ml.Dice(d, m, method=method)
     return exp
 
+
 @pytest.fixture
 def binary_classification_exp_object_out_of_order(method="random"):
     backend = 'sklearn'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,15 @@ def binary_classification_exp_object(method="random"):
     exp = dice_ml.Dice(d, m, method=method)
     return exp
 
+@pytest.fixture
+def binary_classification_exp_object_out_of_order(method="random"):
+    backend = 'sklearn'
+    dataset = helpers.load_outcome_not_last_column_dataset()
+    d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
+    ML_modelpath = helpers.get_custom_dataset_modelpath_pipeline_binary()
+    m = dice_ml.Model(model_path=ML_modelpath, backend=backend)
+    exp = dice_ml.Dice(d, m, method=method)
+    return exp
 
 @pytest.fixture
 def multi_classification_exp_object(method="random"):

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -163,10 +163,8 @@ class TestErrorCasesPublicDataInterface:
 
     def test_min_max_equal(self):
         dataset = helpers.load_min_max_equal_dataset()
-        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
-                         outcome_name='Outcome')
+        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
         assert all(dice_data.normalize_data(dice_data.data_df)['Numerical'] == 0)
-
 
     def test_unseen_continuous_features_precision(self):
         iris = load_iris(as_frame=True)

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -134,7 +134,6 @@ class TestErrorCasesPublicDataInterface:
         with pytest.raises(ValueError) as ve:
             dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
                          outcome_name='Outcome')
-        print(ve)
         assert "Outcome should be the last column! Please reorder!" in str(ve)
 
     def test_unseen_continuous_feature_names(self):

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -131,10 +131,8 @@ class TestErrorCasesPublicDataInterface:
 
     def test_outcome_not_last_column(self):
         dataset = helpers.load_outcome_not_last_column_dataset()
-        with pytest.raises(ValueError) as ve:
-            dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
+        dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
                          outcome_name='Outcome')
-        assert "Outcome should be the last column! Please reorder!" in str(ve)
 
     def test_unseen_continuous_feature_names(self):
         iris = load_iris(as_frame=True)

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -129,11 +129,6 @@ class TestErrorCasesPublicDataInterface:
 
         assert "outcome_name invalid not found in" in str(ucve)
 
-    def test_outcome_not_last_column(self):
-        dataset = helpers.load_outcome_not_last_column_dataset()
-        dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
-                         outcome_name='Outcome')
-
     def test_unseen_continuous_feature_names(self):
         iris = load_iris(as_frame=True)
         feature_names = iris.feature_names

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -129,6 +129,14 @@ class TestErrorCasesPublicDataInterface:
 
         assert "outcome_name invalid not found in" in str(ucve)
 
+    def test_outcome_not_last_column(self):
+        dataset = helpers.load_outcome_not_last_column_dataset()
+        with pytest.raises(ValueError) as ve:
+            dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
+                         outcome_name='Outcome')
+        print(ve)
+        assert "Outcome should be the last column! Please reorder!" in str(ve)
+
     def test_unseen_continuous_feature_names(self):
         iris = load_iris(as_frame=True)
         feature_names = iris.feature_names
@@ -152,6 +160,13 @@ class TestErrorCasesPublicDataInterface:
                          outcome_name='target', permitted_range=permitted_range)
 
         assert "permitted_range contains some feature names which are not part of columns in dataframe" in str(ucve)
+
+    def test_min_max_equal(self):
+        dataset = helpers.load_min_max_equal_dataset()
+        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'],
+                         outcome_name='Outcome')
+        assert all(dice_data.normalize_data(dice_data.data_df)['Numerical'] == 0)
+
 
     def test_unseen_continuous_features_precision(self):
         iris = load_iris(as_frame=True)

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -46,6 +46,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs", [(7, 3)])
     def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
         with pytest.raises(UserConfigValidationException):
+            self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_1)
             self.exp._generate_counterfactuals(query_instance=sample_custom_query_1, total_CFs=total_CFs,
                                                desired_class=desired_class)
 
@@ -60,6 +61,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
                              [(1, 2, "all", "kdtree"), (1, 2, "all", "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
@@ -71,6 +73,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
                              [(1, 2, ["Numerical"], "kdtree"), (1, 2, ["Numerical"], "random")])
     def test_features_to_vary(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
@@ -86,6 +89,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, permitted_range, initialization",
                              [(1, 2, {'Numerical': [10, 15]}, "kdtree"), (1, 2, {'Numerical': [10, 15]}, "random")])
     def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, permitted_range, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
@@ -103,6 +107,7 @@ class TestDiceGeneticBinaryClassificationMethods:
                               (1, 2, {'Categorical': ['a', 'c']}, "random")])
     def test_permitted_range_categorical(self, desired_class, total_CFs, sample_custom_query_2, permitted_range,
                                          initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
@@ -130,6 +135,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
                              [(0, 7, "kdtree", 0), (0, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
@@ -141,6 +147,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, initialization",
                              [(0, 0, "kdtree"), (0, 0, "random")])
     def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                            total_CFs=total_CFs, desired_class=desired_class,
@@ -149,6 +156,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     # Testing the custom predict function
     @pytest.mark.parametrize("desired_class", [2])
     def test_predict_custom(self, desired_class, sample_custom_query_2, mocker):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.yloss_type = 'hinge_loss'
         mocker.patch('dice_ml.explainer_interfaces.dice_genetic.DiceGenetic.label_decode', return_value=None)
         mocker.patch('dice_ml.model_interfaces.base_model.BaseModel.get_output', return_value=[[0, 0.5, 0.5]])
@@ -164,6 +172,7 @@ class TestDiceGeneticMultiClassificationMethods:
     # Testing that the counterfactuals are in the desired class
     @pytest.mark.parametrize("desired_class, total_CFs, initialization", [(2, 2, "kdtree"), (2, 2, "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
@@ -174,6 +183,7 @@ class TestDiceGeneticMultiClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
                              [(2, 7, "kdtree", 0), (2, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
@@ -185,6 +195,7 @@ class TestDiceGeneticMultiClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, initialization",
                              [(2, 0, "kdtree"), (2, 0, "random")])
     def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                            total_CFs=total_CFs, desired_class=desired_class,
@@ -193,6 +204,7 @@ class TestDiceGeneticMultiClassificationMethods:
     # Testing the custom predict function
     @pytest.mark.parametrize("desired_class", [2])
     def test_predict_custom(self, desired_class, sample_custom_query_2, mocker):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.yloss_type = 'hinge_loss'
         mocker.patch('dice_ml.explainer_interfaces.dice_genetic.DiceGenetic.label_decode', return_value=None)
         mocker.patch('dice_ml.model_interfaces.base_model.BaseModel.get_output', return_value=[[0, 0.5, 0.5]])
@@ -209,6 +221,7 @@ class TestDiceGeneticRegressionMethods:
     @pytest.mark.parametrize("desired_range, total_CFs, initialization",
                              [([1, 2.8], 2, "kdtree"), ([1, 2.8], 2, "random")])
     def test_desired_range(self, desired_range, sample_custom_query_2, total_CFs, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_range=desired_range,
@@ -221,6 +234,7 @@ class TestDiceGeneticRegressionMethods:
     @pytest.mark.parametrize("desired_range, total_CFs, initialization, maxiterations",
                              [([1, 2.8], 7, "kdtree", 0), ([1, 2.8], 7, "random", 0)])
     def test_maxiter(self, desired_range, sample_custom_query_2, total_CFs, initialization, maxiterations):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_range=desired_range,
@@ -232,6 +246,7 @@ class TestDiceGeneticRegressionMethods:
     @pytest.mark.parametrize("desired_range, total_CFs, initialization",
                              [([1, 2.8], 0, "kdtree"), ([1, 2.8], 0, "random")])
     def test_zero_cfs(self, desired_range, sample_custom_query_2, total_CFs, initialization):
+        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
         self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
         self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
                                            total_CFs=total_CFs, desired_range=desired_range,

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -46,8 +46,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs", [(7, 3)])
     def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
         with pytest.raises(UserConfigValidationException):
-            self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_1)
-            self.exp._generate_counterfactuals(query_instance=sample_custom_query_1, total_CFs=total_CFs,
+            self.exp.generate_counterfactuals(query_instances=sample_custom_query_1, total_CFs=total_CFs,
                                                desired_class=desired_class)
 
     # When a query's feature value is not within the permitted range and the feature is not allowed to vary
@@ -61,97 +60,82 @@ class TestDiceGeneticBinaryClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
                              [(1, 2, "all", "kdtree"), (1, 2, "all", "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization)
-        assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
+        for cfs_example in ans.cf_examples_list:
+            assert all(cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing that the features_to_vary argument actually varies only the features that you wish to vary
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
                              [(1, 2, ["Numerical"], "kdtree"), (1, 2, ["Numerical"], "random")])
     def test_features_to_vary(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        features_to_vary = self.exp.setup(features_to_vary, None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  features_to_vary=features_to_vary,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization)
 
-        for feature in self.exp.data_interface.feature_names:
-            if feature not in features_to_vary:
-                assert all(ans.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
+        for cfs_example in ans.cf_examples_list:
+            for feature in self.exp.data_interface.feature_names:
+                if feature not in features_to_vary:
+                    assert all(cfs_example.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
                            range(total_CFs))
 
     # Testing that the permitted_range argument actually varies the features only within the permitted_range
-    @pytest.mark.parametrize("desired_class, total_CFs, permitted_range, initialization",
-                             [(1, 2, {'Numerical': [10, 15]}, "kdtree"), (1, 2, {'Numerical': [10, 15]}, "random")])
-    def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, permitted_range, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, permitted_range, initialization",
+                             [(1, 2, "all", {'Numerical': [10, 15]}, "kdtree"), (1, 2, "all", {'Numerical': [10, 15]}, "random")])
+    def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, permitted_range, initialization):
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization)
 
-        for feature in permitted_range:
-            assert all(
-                permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
-                in range(total_CFs))
+        for cfs_example in ans.cf_examples_list:
+            for feature in permitted_range:
+                assert all(
+                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                    in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables
-    @pytest.mark.parametrize("desired_class, total_CFs, permitted_range, initialization",
-                             [(1, 2, {'Categorical': ['a', 'c']}, "kdtree"),
-                              (1, 2, {'Categorical': ['a', 'c']}, "random")])
-    def test_permitted_range_categorical(self, desired_class, total_CFs, sample_custom_query_2, permitted_range,
+    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, permitted_range, initialization",
+                             [(1, 2, "all", {'Categorical': ['a', 'c']}, "kdtree"),
+                              (1, 2, "all", {'Categorical': ['a', 'c']}, "random")])
+    def test_permitted_range_categorical(self, desired_class, total_CFs, features_to_vary, sample_custom_query_2, permitted_range,
                                          initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        features_to_vary = self.exp.setup("all", permitted_range, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  features_to_vary=features_to_vary, permitted_range=permitted_range,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization)
 
-        for feature in permitted_range:
-            assert all(
-                permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
-                in range(total_CFs))
+        for cfs_example in ans.cf_examples_list:
+            for feature in permitted_range:
+                assert all(
+                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                    in range(total_CFs))
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
-    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_3, total_CFs):
+    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary", [(0, 1, "all")])
+    def test_query_instance_outside_bounds(self, desired_class, sample_custom_query_3, total_CFs, features_to_vary):
         with pytest.raises(ValueError):
-            self.exp.setup("all", None, sample_custom_query_3, "inverse_mad")
+            self.exp.setup(features_to_vary, None, sample_custom_query_3, "inverse_mad")
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
-    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 1)])
-    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs):
+    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary", [(0, 1, "all")])
+    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs, features_to_vary):
         with pytest.raises(ValueError):
-            self.exp.setup("all", None, sample_custom_query_5, "inverse_mad")
+            self.exp.setup(features_to_vary, None, sample_custom_query_5, "inverse_mad")
 
     # Testing if only valid cfs are found after maxiterations
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
                              [(0, 7, "kdtree", 0), (0, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert i == desired_class
-
-    # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization",
-                             [(0, 0, "kdtree"), (0, 0, "random")])
-    def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class,
-                                           initialization=initialization)
+        for cfs_example in ans.cf_examples_list:
+            for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
+                assert i == desired_class
 
     # Testing the custom predict function
     @pytest.mark.parametrize("desired_class", [2])
@@ -172,34 +156,22 @@ class TestDiceGeneticMultiClassificationMethods:
     # Testing that the counterfactuals are in the desired class
     @pytest.mark.parametrize("desired_class, total_CFs, initialization", [(2, 2, "kdtree"), (2, 2, "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
-        assert all(ans.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
+                                                initialization=initialization)
+        for cfs_example in ans.cf_examples_list:
+            assert all(cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing if only valid cfs are found after maxiterations
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
                              [(2, 7, "kdtree", 0), (2, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_class=desired_class,
                                                  initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert i == desired_class
-
-    # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_class, total_CFs, initialization",
-                             [(2, 0, "kdtree"), (2, 0, "random")])
-    def test_zero_cfs(self, desired_class, sample_custom_query_2, total_CFs, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_class=desired_class,
-                                           initialization=initialization)
+        for cfs_example in ans.cf_examples_list:
+            for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
+                assert i == desired_class
 
     # Testing the custom predict function
     @pytest.mark.parametrize("desired_class", [2])
@@ -221,33 +193,21 @@ class TestDiceGeneticRegressionMethods:
     @pytest.mark.parametrize("desired_range, total_CFs, initialization",
                              [([1, 2.8], 2, "kdtree"), ([1, 2.8], 2, "random")])
     def test_desired_range(self, desired_range, sample_custom_query_2, total_CFs, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_range=desired_range,
                                                  initialization=initialization)
-        assert all(
-            [desired_range[0]] * total_CFs <= ans.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
-            ans.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
+        for cfs_example in ans.cf_examples_list:
+            assert all(
+                [desired_range[0]] * total_CFs <= cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
+                cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
 
     # Testing if only valid cfs are found after maxiterations
     @pytest.mark.parametrize("desired_range, total_CFs, initialization, maxiterations",
                              [([1, 2.8], 7, "kdtree", 0), ([1, 2.8], 7, "random", 0)])
     def test_maxiter(self, desired_range, sample_custom_query_2, total_CFs, initialization, maxiterations):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        ans = self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
+        ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                                  total_CFs=total_CFs, desired_range=desired_range,
                                                  initialization=initialization, maxiterations=maxiterations)
-        for i in ans.final_cfs_df[self.exp.data_interface.outcome_name].values:
-            assert desired_range[0] <= i <= desired_range[1]
-
-    # Testing for 0 CFs needed
-    @pytest.mark.parametrize("desired_range, total_CFs, initialization",
-                             [([1, 2.8], 0, "kdtree"), ([1, 2.8], 0, "random")])
-    def test_zero_cfs(self, desired_range, sample_custom_query_2, total_CFs, initialization):
-        self.exp.data_interface.set_continuous_feature_indexes(query_instance=sample_custom_query_2)
-        self.exp.setup("all", None, sample_custom_query_2, "inverse_mad")
-        self.exp._generate_counterfactuals(query_instance=sample_custom_query_2,
-                                           total_CFs=total_CFs, desired_range=desired_range,
-                                           initialization=initialization)
+        for cfs_example in ans.cf_examples_list:
+            for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
+                assert desired_range[0] <= i <= desired_range[1]

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -121,8 +121,8 @@ class TestDiceGeneticBinaryClassificationMethods:
             self.exp.setup(features_to_vary, None, sample_custom_query_3, "inverse_mad")
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
-    @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary", [(0, 1, "all")])
-    def test_query_instance_unknown_column(self, desired_class, sample_custom_query_5, total_CFs, features_to_vary):
+    @pytest.mark.parametrize("features_to_vary", [("all")])
+    def test_query_instance_unknown_column(self, sample_custom_query_5, features_to_vary):
         with pytest.raises(ValueError):
             self.exp.setup(features_to_vary, None, sample_custom_query_5, "inverse_mad")
 

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -47,7 +47,7 @@ class TestDiceGeneticBinaryClassificationMethods:
     def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
         with pytest.raises(UserConfigValidationException):
             self.exp.generate_counterfactuals(query_instances=sample_custom_query_1, total_CFs=total_CFs,
-                                               desired_class=desired_class)
+                                              desired_class=desired_class)
 
     # When a query's feature value is not within the permitted range and the feature is not allowed to vary
     @pytest.mark.parametrize("features_to_vary, permitted_range, feature_weights",
@@ -61,57 +61,64 @@ class TestDiceGeneticBinaryClassificationMethods:
                              [(1, 2, "all", "kdtree"), (1, 2, "all", "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                features_to_vary=features_to_vary,
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization)
         for cfs_example in ans.cf_examples_list:
-            assert all(cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
+            assert all(
+                cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing that the features_to_vary argument actually varies only the features that you wish to vary
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, initialization",
                              [(1, 2, ["Numerical"], "kdtree"), (1, 2, ["Numerical"], "random")])
     def test_features_to_vary(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 features_to_vary=features_to_vary,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                features_to_vary=features_to_vary,
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization)
 
         for cfs_example in ans.cf_examples_list:
             for feature in self.exp.data_interface.feature_names:
                 if feature not in features_to_vary:
-                    assert all(cfs_example.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
-                           range(total_CFs))
+                    assert all(
+                        cfs_example.final_cfs_df[feature].values[i] == sample_custom_query_2[feature].values[0] for i in
+                        range(total_CFs))
 
     # Testing that the permitted_range argument actually varies the features only within the permitted_range
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, permitted_range, initialization",
-                             [(1, 2, "all", {'Numerical': [10, 15]}, "kdtree"), (1, 2, "all", {'Numerical': [10, 15]}, "random")])
-    def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, permitted_range, initialization):
+                             [(1, 2, "all", {'Numerical': [10, 15]}, "kdtree"),
+                              (1, 2, "all", {'Numerical': [10, 15]}, "random")])
+    def test_permitted_range(self, desired_class, sample_custom_query_2, total_CFs, features_to_vary, permitted_range,
+                             initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 features_to_vary=features_to_vary, permitted_range=permitted_range,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                features_to_vary=features_to_vary, permitted_range=permitted_range,
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization)
 
         for cfs_example in ans.cf_examples_list:
             for feature in permitted_range:
                 assert all(
-                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <=
+                    permitted_range[feature][1] for i
                     in range(total_CFs))
 
     # Testing if you can provide permitted_range for categorical variables
     @pytest.mark.parametrize("desired_class, total_CFs, features_to_vary, permitted_range, initialization",
                              [(1, 2, "all", {'Categorical': ['a', 'c']}, "kdtree"),
                               (1, 2, "all", {'Categorical': ['a', 'c']}, "random")])
-    def test_permitted_range_categorical(self, desired_class, total_CFs, features_to_vary, sample_custom_query_2, permitted_range,
+    def test_permitted_range_categorical(self, desired_class, total_CFs, features_to_vary, sample_custom_query_2,
+                                         permitted_range,
                                          initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 features_to_vary=features_to_vary, permitted_range=permitted_range,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization)
+                                                features_to_vary=features_to_vary, permitted_range=permitted_range,
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization)
 
         for cfs_example in ans.cf_examples_list:
             for feature in permitted_range:
                 assert all(
-                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
+                    permitted_range[feature][0] <= cfs_example.final_cfs_df[feature].values[i] <=
+                    permitted_range[feature][1] for i
                     in range(total_CFs))
 
     # Testing if an error is thrown when the query instance has an unknown categorical variable
@@ -131,8 +138,8 @@ class TestDiceGeneticBinaryClassificationMethods:
                              [(0, 7, "kdtree", 0), (0, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization, maxiterations=maxiterations)
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization, maxiterations=maxiterations)
         for cfs_example in ans.cf_examples_list:
             for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
                 assert i == desired_class
@@ -157,18 +164,19 @@ class TestDiceGeneticMultiClassificationMethods:
     @pytest.mark.parametrize("desired_class, total_CFs, initialization", [(2, 2, "kdtree"), (2, 2, "random")])
     def test_desired_class(self, desired_class, sample_custom_query_2, total_CFs, initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
+                                                total_CFs=total_CFs, desired_class=desired_class,
                                                 initialization=initialization)
         for cfs_example in ans.cf_examples_list:
-            assert all(cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
+            assert all(
+                cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values == [desired_class] * total_CFs)
 
     # Testing if only valid cfs are found after maxiterations
     @pytest.mark.parametrize("desired_class, total_CFs, initialization, maxiterations",
                              [(2, 7, "kdtree", 0), (2, 7, "random", 0)])
     def test_maxiter(self, desired_class, sample_custom_query_2, total_CFs, initialization, maxiterations):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_class=desired_class,
-                                                 initialization=initialization, maxiterations=maxiterations)
+                                                total_CFs=total_CFs, desired_class=desired_class,
+                                                initialization=initialization, maxiterations=maxiterations)
         for cfs_example in ans.cf_examples_list:
             for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
                 assert i == desired_class
@@ -194,11 +202,12 @@ class TestDiceGeneticRegressionMethods:
                              [([1, 2.8], 2, "kdtree"), ([1, 2.8], 2, "random")])
     def test_desired_range(self, desired_range, sample_custom_query_2, total_CFs, initialization):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_range=desired_range,
-                                                 initialization=initialization)
+                                                total_CFs=total_CFs, desired_range=desired_range,
+                                                initialization=initialization)
         for cfs_example in ans.cf_examples_list:
             assert all(
-                [desired_range[0]] * total_CFs <= cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values) and all(
+                [desired_range[0]] * total_CFs <= cfs_example.final_cfs_df[
+                    self.exp.data_interface.outcome_name].values) and all(
                 cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values <= [desired_range[1]] * total_CFs)
 
     # Testing if only valid cfs are found after maxiterations
@@ -206,8 +215,8 @@ class TestDiceGeneticRegressionMethods:
                              [([1, 2.8], 7, "kdtree", 0), ([1, 2.8], 7, "random", 0)])
     def test_maxiter(self, desired_range, sample_custom_query_2, total_CFs, initialization, maxiterations):
         ans = self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                                 total_CFs=total_CFs, desired_range=desired_range,
-                                                 initialization=initialization, maxiterations=maxiterations)
+                                                total_CFs=total_CFs, desired_range=desired_range,
+                                                initialization=initialization, maxiterations=maxiterations)
         for cfs_example in ans.cf_examples_list:
             for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
                 assert desired_range[0] <= i <= desired_range[1]

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -29,6 +29,7 @@ class TestExplainerBaseBinaryClassification:
             permitted_range=None,
             features_to_vary='all')
 
+
 class TestExplainerBaseMultiClassClassification:
 
     @pytest.mark.parametrize("desired_class, multi_classification_exp_object",

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -16,6 +16,18 @@ class TestExplainerBaseBinaryClassification:
                     total_CFs=0,
                     desired_class=desired_class)
 
+    @pytest.mark.parametrize("desired_class, binary_classification_exp_object_out_of_order",
+                             [(1, 'random'), (1, 'genetic'), (1, 'kdtree')],
+                             indirect=['binary_classification_exp_object_out_of_order'])
+    def test_columns_out_of_order(self, desired_class, binary_classification_exp_object_out_of_order, sample_custom_query_1):
+        exp = binary_classification_exp_object_out_of_order  # explainer object
+        exp._generate_counterfactuals(
+            query_instance=sample_custom_query_1,
+            total_CFs=0,
+            desired_class=desired_class,
+            desired_range=None,
+            permitted_range=None,
+            features_to_vary='all')
 
 class TestExplainerBaseMultiClassClassification:
 


### PR DESCRIPTION
In response to #168 
- Before, we were normalising by doing (value - min_value)/(max_value - min_value). Now, if min_value == max_value, setting the value to 0, according to https://stats.stackexchange.com/questions/441342/same-value-of-min-and-max-in-min-max-normalisation
- Added check to ensure that predictions aren't numpy.float32
- Added support for columns in query_instance not being in the same order as the dataset, shifted the function to base_data_interface
- Added test to check the case when min & max of a column are equal
- Added test to check that no error is raised when the outcome is not the last column
- Refactored test_dice_genetic to use generate_counterfactuals instead of _generate_counterfactuals
- Removed test_zero_cfs as an exception is raised by explainer_base