### PR TITLE
Continue feature importance computation if no counterfactuals found

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -326,6 +326,10 @@ class ExplainerBase(ABC):
                 df = cf_examples.final_cfs_df_sparse
             else:
                 df = cf_examples.final_cfs_df
+
+            if df is None:
+                continue
+
             for index, row in df.iterrows():
                 for col in self.data_interface.continuous_feature_names:
                     if not np.isclose(org_instance[col].iat[0], row[col]):


### PR DESCRIPTION
In cases when the counterfactual for a query point are not found, the local importance computation loop would fail trying to access a None object. Hence, continuing the loop in event when the counterfactuals are  not found for a query point.

Signed-off-by: gaugup <gaugup@microsoft.com>