### PR TITLE
Fix serialization counterfactual explanations when no CFs found

### DIFF
--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -63,8 +63,13 @@ class CounterfactualExamples:
 
     def __eq__(self, other_counterfactual_example):
         if isinstance(other_counterfactual_example, CounterfactualExamples):
+            fina_cfs_df = (self.final_cfs_df is None) == (other_counterfactual_example.final_cfs_df is None)
+            final_cfs_df_sparse = (self.final_cfs_df_sparse is None) == (other_counterfactual_example.final_cfs_df_sparse is None)
             return self.desired_class == other_counterfactual_example.desired_class and \
-                    self.desired_range == self.desired_range
+                    self.desired_range == other_counterfactual_example.desired_range and \
+                    self.model_type == other_counterfactual_example.model_type and \
+                    (self.final_cfs_df is None) == (other_counterfactual_example.final_cfs_df is None) and \
+                    (self.final_cfs_df_sparse is None) == (other_counterfactual_example.final_cfs_df_sparse is None)
         return False
 
     def _dump_output(self, content, show_only_changes=False, is_notebook_console=False):
@@ -184,7 +189,10 @@ class CounterfactualExamples:
             feature_names = self.test_instance_df.columns.tolist().copy()
             feature_names.remove(dummy_data_interface.outcome_name)
             test_instance_df_as_list = self.test_instance_df.values.tolist()
-            final_cfs_df_as_as_list = df.values.tolist()
+            if df is not None:
+                final_cfs_df_as_as_list = df.values.tolist()
+            else:
+                final_cfs_df_as_as_list = None
 
             alternate_obj = {
                 _DiverseCFV2SchemaConstants.TEST_INSTANCE_LIST: test_instance_df_as_list,
@@ -204,7 +212,10 @@ class CounterfactualExamples:
         if cf_example_dict.get(_DiverseCFV1SchemaConstants.TEST_INSTANCE_DF) is not None:
             test_instance_df = pd.read_json(cf_example_dict[
                 _DiverseCFV1SchemaConstants.TEST_INSTANCE_DF])
-            cfs_df = pd.read_json(cf_example_dict[_DiverseCFV1SchemaConstants.FINAL_CFS_DF])
+            if cf_example_dict[_DiverseCFV1SchemaConstants.FINAL_CFS_DF] is not None:
+                cfs_df = pd.read_json(cf_example_dict[_DiverseCFV1SchemaConstants.FINAL_CFS_DF])
+            else:
+                cfs_df = None
 
             # Creating the object for dummy_data_interface
             dummy_data_interface = DummyDataInterface(**cf_example_dict[_DiverseCFV1SchemaConstants.DATA_INTERFACE])
@@ -228,8 +239,11 @@ class CounterfactualExamples:
 
             test_instance_df = pd.DataFrame(data=test_instance_list,
                                             columns=feature_names_including_target)
-            cfs_df = pd.DataFrame(data=final_cfs_list,
-                                  columns=feature_names_including_target)
+            if final_cfs_list is not None:
+                cfs_df = pd.DataFrame(data=final_cfs_list,
+                                      columns=feature_names_including_target)
+            else:
+                cfs_df = None
             # Creating the object for dummy_data_interface
             dummy_data_interface = DummyDataInterface(**data_interface)
             return CounterfactualExamples(data_interface=dummy_data_interface,

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -63,13 +63,13 @@ class CounterfactualExamples:
 
     def __eq__(self, other_counterfactual_example):
         if isinstance(other_counterfactual_example, CounterfactualExamples):
-            fina_cfs_df = (self.final_cfs_df is None) == (other_counterfactual_example.final_cfs_df is None)
-            final_cfs_df_sparse = (self.final_cfs_df_sparse is None) == (other_counterfactual_example.final_cfs_df_sparse is None)
             return self.desired_class == other_counterfactual_example.desired_class and \
-                    self.desired_range == other_counterfactual_example.desired_range and \
-                    self.model_type == other_counterfactual_example.model_type and \
-                    (self.final_cfs_df is None) == (other_counterfactual_example.final_cfs_df is None) and \
-                    (self.final_cfs_df_sparse is None) == (other_counterfactual_example.final_cfs_df_sparse is None)
+                        self.desired_range == other_counterfactual_example.desired_range and \
+                        self.model_type == other_counterfactual_example.model_type and \
+                        (self.final_cfs_df is None) == \
+                        (other_counterfactual_example.final_cfs_df is None) and \
+                        (self.final_cfs_df_sparse is None) == \
+                        (other_counterfactual_example.final_cfs_df_sparse is None)
         return False
 
     def _dump_output(self, content, show_only_changes=False, is_notebook_console=False):

--- a/dice_ml/schema/counterfactual_explanations_v2.0.json
+++ b/dice_ml/schema/counterfactual_explanations_v2.0.json
@@ -8,7 +8,7 @@
             "description": "The list of the computed counterfactual examples.",
 			"type": "array",
 			"items": {
-				"type": "array"
+				"type": ["array", "null"]
 			}
 		},
 		"test_data": {

--- a/tests/test_counterfactual_explanations.py
+++ b/tests/test_counterfactual_explanations.py
@@ -151,9 +151,9 @@ class TestSerializationCounterfactualExplanations:
 
     @pytest.mark.parametrize("version", ['1.0', '2.0'])
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 2)])
-    def test_random_counterfactual_explanations_output(self, desired_class,
-                                                       sample_custom_query_1, total_CFs,
-                                                       version):
+    def test_counterfactual_explanations_output(self, desired_class,
+                                                sample_custom_query_1, total_CFs,
+                                                version):
         counterfactual_explanations = self.exp.generate_counterfactuals(
             query_instances=sample_custom_query_1, desired_class=desired_class,
             total_CFs=total_CFs)
@@ -173,8 +173,8 @@ class TestSerializationCounterfactualExplanations:
 
     @pytest.mark.parametrize("version", ['1.0', '2.0'])
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 10)])
-    def test_random_local_importance_output(self, desired_class, sample_custom_query_1,
-                                            total_CFs, version):
+    def test_local_importance_output(self, desired_class, sample_custom_query_1,
+                                     total_CFs, version):
         counterfactual_explanations = self.exp.local_feature_importance(
             query_instances=sample_custom_query_1, desired_class=desired_class,
             total_CFs=total_CFs)
@@ -196,8 +196,8 @@ class TestSerializationCounterfactualExplanations:
 
     @pytest.mark.parametrize("version", ['1.0', '2.0'])
     @pytest.mark.parametrize("desired_class, total_CFs", [(0, 10)])
-    def test_random_summary_importance_output(self, desired_class, sample_custom_query_10,
-                                              total_CFs, version):
+    def test_summary_importance_output(self, desired_class, sample_custom_query_10,
+                                       total_CFs, version):
         counterfactual_explanations = self.exp.global_feature_importance(
             query_instances=sample_custom_query_10, desired_class=desired_class,
             total_CFs=total_CFs)
@@ -239,6 +239,71 @@ class TestSerializationCounterfactualExplanations:
         self.verify_counterfactual_explanations(recovered_counterfactual_explanations, None,
                                                 0, version)
 
+        assert counterfactual_explanations == recovered_counterfactual_explanations
+
+    @pytest.mark.parametrize("version", ['1.0', '2.0'])
+    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 2)])
+    def test_no_counterfactuals_found(self, desired_class,
+                                      sample_custom_query_1, total_CFs,
+                                      version):
+        counterfactual_explanations = self.exp.generate_counterfactuals(
+            query_instances=sample_custom_query_1, desired_class=desired_class,
+            total_CFs=total_CFs)
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df = None
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df_sparse = None
+        self.verify_counterfactual_explanations(counterfactual_explanations, None,
+                                                sample_custom_query_1.shape[0], version)
+        counterfactual_explanations_as_json = counterfactual_explanations.to_json()
+        recovered_counterfactual_explanations = CounterfactualExplanations.from_json(
+            counterfactual_explanations_as_json)
+        self.verify_counterfactual_explanations(recovered_counterfactual_explanations, None,
+                                                sample_custom_query_1.shape[0], version)
+        assert counterfactual_explanations == recovered_counterfactual_explanations
+
+    @pytest.mark.parametrize("version", ['1.0', '2.0'])
+    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 10)])
+    def test_no_counterfactuals_found_local_importance(self, desired_class,
+                                                       sample_custom_query_1, total_CFs,
+                                                       version):
+        counterfactual_explanations = self.exp.local_feature_importance(
+            query_instances=sample_custom_query_1, desired_class=desired_class,
+            total_CFs=total_CFs)
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df = None
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df_sparse = None
+        self.verify_counterfactual_explanations(counterfactual_explanations, None,
+                                                sample_custom_query_1.shape[0], version,
+                                                local_importance_available=True)
+        counterfactual_explanations_as_json = counterfactual_explanations.to_json()
+        recovered_counterfactual_explanations = CounterfactualExplanations.from_json(
+            counterfactual_explanations_as_json)
+        self.verify_counterfactual_explanations(recovered_counterfactual_explanations, None,
+                                                sample_custom_query_1.shape[0], version,
+                                                local_importance_available=True)
+        assert counterfactual_explanations == recovered_counterfactual_explanations
+
+    @pytest.mark.parametrize("version", ['1.0', '2.0'])
+    @pytest.mark.parametrize("desired_class, total_CFs", [(0, 10)])
+    def test_no_counterfactuals_found_summary_importance(self, desired_class,
+                                                         sample_custom_query_10, total_CFs,
+                                                         version):
+        counterfactual_explanations = self.exp.global_feature_importance(
+            query_instances=sample_custom_query_10, desired_class=desired_class,
+            total_CFs=total_CFs)
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df = None
+        counterfactual_explanations.cf_examples_list[0].final_cfs_df_sparse = None
+        counterfactual_explanations.cf_examples_list[9].final_cfs_df = None
+        counterfactual_explanations.cf_examples_list[9].final_cfs_df_sparse = None
+        self.verify_counterfactual_explanations(counterfactual_explanations, None,
+                                                sample_custom_query_10.shape[0], version,
+                                                local_importance_available=True,
+                                                summary_importance_available=True)
+        counterfactual_explanations_as_json = counterfactual_explanations.to_json()
+        recovered_counterfactual_explanations = CounterfactualExplanations.from_json(
+            counterfactual_explanations_as_json)
+        self.verify_counterfactual_explanations(recovered_counterfactual_explanations, None,
+                                                sample_custom_query_10.shape[0], version,
+                                                local_importance_available=True,
+                                                summary_importance_available=True)
         assert counterfactual_explanations == recovered_counterfactual_explanations
 
     @pytest.mark.parametrize('unsupported_version', ['3.0', ''])


### PR DESCRIPTION
It seems the serialization of counterfactual explanations fails if no counterfactuals are found. Hence, fixing this and adding tests.

Signed-off-by: gaugup <gaugup@microsoft.com>