### PR TITLE
Fix feature importance calculation

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -243,7 +243,7 @@ class ExplainerBase(ABC):
                   the list of counterfactuals per input, local feature importances per
                   input, and the global feature importance summarized over all inputs.
         """
-        if len(query_instances) < 10:
+        if query_instances is not None and len(query_instances) < 10:
             raise UserConfigValidationException("The number of query instances should be greater than or equal to 10")
         if cf_examples_list is not None:
             if any([len(cf_examples.final_cfs_df) < 10 for cf_examples in cf_examples_list]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,25 @@ def sample_custom_query_10():
 
 
 @pytest.fixture
+def sample_counterfactual_example_dummy():
+    """
+    Returns a sample counterfactual example
+    """
+    return pd.DataFrame(
+        {
+            'Categorical': ['a', 'b', 'c', 'a', 'b', 
+                            'c', 'a', 'b', 'c', 'a',
+                            'a', 'b', 'c', 'c', 'c'],
+            'Numerical': [25, 50, 75, 100, 125,
+                          150, 175, 200, 225, 250,
+                          150, 175, 200, 225, 250],
+            'Outcome': [1, 1, 1, 1, 1,
+                        1, 1, 1, 1, 1,
+                        1, 1, 1, 1, 1]
+        }
+    )
+
+@pytest.fixture
 def create_iris_data():
     iris = load_iris()
     x_train, x_test, y_train, y_test = train_test_split(

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -1,9 +1,16 @@
+import pandas as pd
 import pytest
+
 from dice_ml.utils.exception import UserConfigValidationException
 from dice_ml.explainer_interfaces.explainer_base import ExplainerBase
 
 
 class TestExplainerBaseBinaryClassification:
+
+    def _verify_feature_importance(self, feature_importance):
+        if feature_importance is not None:
+            for key in feature_importance:
+                assert feature_importance[key] >= 0.0 and feature_importance[key] <= 1.0
 
     @pytest.mark.parametrize("desired_class, binary_classification_exp_object",
                              [(1, 'random'), (1, 'genetic'), (1, 'kdtree')],
@@ -15,6 +22,62 @@ class TestExplainerBaseBinaryClassification:
                     query_instances=[sample_custom_query_1],
                     total_CFs=0,
                     desired_class=desired_class)
+
+    @pytest.mark.parametrize("desired_class, binary_classification_exp_object",
+                             [(1, 'random')],
+                             indirect=['binary_classification_exp_object'])
+    def test_local_feature_importance(self, desired_class, binary_classification_exp_object,
+                                      sample_custom_query_1, sample_counterfactual_example_dummy):
+        exp = binary_classification_exp_object  # explainer object
+        sample_custom_query = pd.concat([sample_custom_query_1, sample_custom_query_1])
+        cf_explanations = exp.generate_counterfactuals(
+                    query_instances=sample_custom_query,
+                    total_CFs=15,
+                    desired_class=desired_class)
+
+        cf_explanations.cf_examples_list[0].final_cfs_df = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[0].final_cfs_df_sparse = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[0].final_cfs_df.drop([0, 1, 2], inplace=True)
+        cf_explanations.cf_examples_list[0].final_cfs_df_sparse.drop([0, 1, 2], inplace=True)
+
+        cf_explanations.cf_examples_list[1].final_cfs_df = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[1].final_cfs_df_sparse = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[1].final_cfs_df.drop([0], inplace=True)
+        cf_explanations.cf_examples_list[1].final_cfs_df_sparse.drop([0], inplace=True)
+
+        local_importances = exp.local_feature_importance(
+            query_instances=None,
+            cf_examples_list=cf_explanations.cf_examples_list)
+
+        for local_importance in local_importances.local_importance:
+            self._verify_feature_importance(local_importance)
+
+
+    @pytest.mark.parametrize("desired_class, binary_classification_exp_object",
+                             [(1, 'random')],
+                             indirect=['binary_classification_exp_object'])
+    def test_global_feature_importance(self, desired_class, binary_classification_exp_object,
+                                       sample_custom_query_10, sample_counterfactual_example_dummy):
+        exp = binary_classification_exp_object  # explainer object
+        cf_explanations = exp.generate_counterfactuals(
+                    query_instances=sample_custom_query_10,
+                    total_CFs=15,
+                    desired_class=desired_class)
+
+        cf_explanations.cf_examples_list[0].final_cfs_df = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[0].final_cfs_df_sparse = sample_counterfactual_example_dummy.copy()
+        cf_explanations.cf_examples_list[0].final_cfs_df.drop([0, 1, 2, 3, 4], inplace=True)
+        cf_explanations.cf_examples_list[0].final_cfs_df_sparse.drop([0, 1, 2, 3, 4], inplace=True)
+
+        for index in range(1, len(cf_explanations.cf_examples_list)):
+            cf_explanations.cf_examples_list[index].final_cfs_df = sample_counterfactual_example_dummy.copy()
+            cf_explanations.cf_examples_list[index].final_cfs_df_sparse = sample_counterfactual_example_dummy.copy()
+
+        global_importance = exp.global_feature_importance(
+            query_instances=None,
+            cf_examples_list=cf_explanations.cf_examples_list)
+
+        self._verify_feature_importance(global_importance.summary_importance)
 
 
 class TestExplainerBaseMultiClassClassification:


### PR DESCRIPTION
It seems like we use the number of counterfactuals found for query instance 0 as the denominator for computing local and global importances. If the number of counterfactuals for query instance 0 is really small, then the feature importances may become larger than 1.0. Hence, changing the logic to keep track of actual counterfactuals found to correct the feature importance calculation.