### PR TITLE
Fixed negative dimension issue

### DIFF
--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -477,7 +477,6 @@ class DiceGenetic(ExplainerBase):
                     population = new_generation_2
             else:
                 raise SystemError("The number of total_Cfs is greater than the population size!")
-                population = new_generation_1
             iterations += 1
 
         self.cfs_preds = []

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -35,7 +35,6 @@ class DiceGenetic(ExplainerBase):
         self.cf_init_weights = []  # total_CFs, algorithm, features_to_vary
         self.loss_weights = []  # yloss_type, diversity_loss_type, feature_weights
         self.feature_weights_input = ''
-        self.population_size = 25
 
         # Initializing a label encoder to obtain label-encoded values for categorical variables
         self.labelencoder = {}
@@ -212,7 +211,7 @@ class DiceGenetic(ExplainerBase):
         self.do_loss_initializations(yloss_type, diversity_loss_type, feature_weights, encoding='label')
         self.update_hyperparameters(proximity_weight, sparsity_weight, diversity_weight, categorical_penalty)
 
-    def _generate_counterfactuals(self, query_instance, total_CFs, initialization="kdtree", desired_range=None,
+    def _generate_counterfactuals(self, query_instance, total_CFs, population_size=None, initialization="kdtree", desired_range=None,
                                   desired_class="opposite", proximity_weight=0.2, sparsity_weight=0.2,
                                   diversity_weight=5.0, categorical_penalty=0.1, algorithm="DiverseCF",
                                   features_to_vary="all", permitted_range=None, yloss_type="hinge_loss",
@@ -224,6 +223,7 @@ class DiceGenetic(ExplainerBase):
 
         :param query_instance: A dictionary of feature names and values. Test point of interest.
         :param total_CFs: Total number of counterfactuals required.
+        :param population_size: Parameter for user to set the genetic algorithm population size
         :param initialization: Method to use to initialize the population of the genetic algorithm
         :param desired_range: For regression problems. Contains the outcome range to generate counterfactuals in.
         :param desired_class: For classification problems. Desired counterfactual class - can take 0 or 1.
@@ -260,6 +260,14 @@ class DiceGenetic(ExplainerBase):
         :return: A CounterfactualExamples object to store and visualize the resulting counterfactual explanations
                  (see diverse_counterfactuals.py).
         """
+        if population_size is None:
+            self.population_size = 10 * total_CFs
+        else:
+            self.population_size = population_size
+
+        if self.population_size < total_CFs:
+            raise ValueError("Population size must be larger than the total number of cfs desired")
+
         self.start_time = timeit.default_timer()
 
         features_to_vary = self.setup(features_to_vary, permitted_range, query_instance, feature_weights)

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -211,14 +211,13 @@ class DiceGenetic(ExplainerBase):
         self.do_loss_initializations(yloss_type, diversity_loss_type, feature_weights, encoding='label')
         self.update_hyperparameters(proximity_weight, sparsity_weight, diversity_weight, categorical_penalty)
 
-    def _generate_counterfactuals(self, query_instance, total_CFs, population_size=None, initialization="kdtree", desired_range=None,
-                                  desired_class="opposite", proximity_weight=0.2, sparsity_weight=0.2,
-                                  diversity_weight=5.0, categorical_penalty=0.1, algorithm="DiverseCF",
-                                  features_to_vary="all", permitted_range=None, yloss_type="hinge_loss",
-                                  diversity_loss_type="dpp_style:inverse_dist", feature_weights="inverse_mad",
-                                  stopping_threshold=0.5, posthoc_sparsity_param=0.1,
-                                  posthoc_sparsity_algorithm="binary",
-                                  maxiterations=500, thresh=1e-2, verbose=False):
+    def _generate_counterfactuals(self, query_instance, total_CFs, population_size=None, initialization="kdtree",
+                                  desired_range=None, desired_class="opposite", proximity_weight=0.2,
+                                  sparsity_weight=0.2, diversity_weight=5.0, categorical_penalty=0.1,
+                                  algorithm="DiverseCF", features_to_vary="all", permitted_range=None,
+                                  yloss_type="hinge_loss", diversity_loss_type="dpp_style:inverse_dist",
+                                  feature_weights="inverse_mad", stopping_threshold=0.5, posthoc_sparsity_param=0.1,
+                                  posthoc_sparsity_algorithm="binary", maxiterations=500, thresh=1e-2, verbose=False):
         """Generates diverse counterfactual explanations
 
         :param query_instance: A dictionary of feature names and values. Test point of interest.

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -161,14 +161,14 @@ class TestDiceGeneticBinaryClassificationMethods:
         custom_preds = self.exp._predict_fn_custom(sample_custom_query_2, desired_class)
         assert custom_preds[0] == desired_class
 
-
     # Testing if an error is thrown when the population size < total_CFs
-    @pytest.mark.parametrize("total_CFs, population_size",[(4, 3)])
+    @pytest.mark.parametrize("total_CFs, population_size", [(4, 3)])
     def test_population_size(self, total_CFs, population_size, sample_custom_query_2):
         with pytest.raises(ValueError) as ve:
             self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                               total_CFs=total_CFs, population_size=population_size)
             assert "Population size must be larger than the total number of cfs desired" in str(ve)
+
 
 class TestDiceGeneticMultiClassificationMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -161,14 +161,6 @@ class TestDiceGeneticBinaryClassificationMethods:
         custom_preds = self.exp._predict_fn_custom(sample_custom_query_2, desired_class)
         assert custom_preds[0] == desired_class
 
-    # Testing if an error is thrown when the population size < total_CFs
-    @pytest.mark.parametrize("total_CFs, population_size", [(4, 3)])
-    def test_population_size(self, total_CFs, population_size, sample_custom_query_2):
-        with pytest.raises(ValueError) as ve:
-            self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
-                                              total_CFs=total_CFs, population_size=population_size)
-            assert "Population size must be larger than the total number of cfs desired" in str(ve)
-
 
 class TestDiceGeneticMultiClassificationMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -162,6 +162,14 @@ class TestDiceGeneticBinaryClassificationMethods:
         assert custom_preds[0] == desired_class
 
 
+    # Testing if an error is thrown when the population size < total_CFs
+    @pytest.mark.parametrize("total_CFs, population_size",[(4, 3)])
+    def test_population_size(self, total_CFs, population_size, sample_custom_query_2):
+        with pytest.raises(ValueError) as ve:
+            self.exp.generate_counterfactuals(query_instances=sample_custom_query_2,
+                                              total_CFs=total_CFs, population_size=population_size)
+            assert "Population size must be larger than the total number of cfs desired" in str(ve)
+
 class TestDiceGeneticMultiClassificationMethods:
     @pytest.fixture(autouse=True)
     def _initiate_exp_object(self, genetic_multi_classification_exp_object):


### PR DESCRIPTION
Signed-off-by: Soundarya Krishnan <soundaryak4898@gmail.com>
- Population size is now set to 10* total_CFs
- If the `rest_members` variable somehow becomes negative, we raise a SystemError exception to be more informative to the user