### PR TITLE
Validate feature_to_vary and perimtted_features in generate_counterfactuals()

### DIFF
--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -147,6 +147,37 @@ class PublicData(_BaseData):
                     )
         self.permitted_range, _ = self.get_features_range(input_permitted_range)
 
+    def check_features_to_vary(self, features_to_vary):
+        if features_to_vary is not None and features_to_vary != 'all':
+            not_training_features = set(features_to_vary) - set(self.feature_names)
+            if len(not_training_features) > 0:
+                raise UserConfigValidationException("Got features {0} which are not present in training data".format(
+                    not_training_features))
+
+    def check_permitted_range(self, permitted_range):
+        if permitted_range is not None:
+            permitted_range_features = list(permitted_range)
+            not_training_features = set(permitted_range_features) - set(self.feature_names)
+            if len(not_training_features) > 0:
+                raise UserConfigValidationException("Got features {0} which are not present in training data".format(
+                    not_training_features))
+
+            for feature in permitted_range_features:
+                if feature in self.categorical_feature_names:
+                    train_categories = self.permitted_range[feature]
+                    for test_category in permitted_range[feature]:
+                        if test_category not in train_categories:
+                            raise UserConfigValidationException(
+                                'The category {0} does not occur in the training data for feature {1}.'
+                                ' Allowed categories are {2}'.format(test_category, feature, train_categories))
+
+    def check_mad_validity(self, feature_weights):
+        """checks feature MAD validity and throw warnings.
+           TODO: add comments as to where this is used if this function is necessary, else remove.
+        """
+        if feature_weights == "inverse_mad":
+            self.get_valid_mads(display_warnings=True, return_mads=False)
+
     def get_features_range(self, permitted_range_input=None):
         ranges = {}
         # Getting default ranges based on the dataset

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -140,6 +140,9 @@ class ExplainerBase(ABC):
         pass
 
     def setup(self, features_to_vary, permitted_range, query_instance, feature_weights):
+        self.data_interface.check_features_to_vary(features_to_vary=features_to_vary)
+        self.data_interface.check_permitted_range(permitted_range)
+
         if features_to_vary == 'all':
             features_to_vary = self.data_interface.feature_names
 
@@ -148,10 +151,11 @@ class ExplainerBase(ABC):
             feature_ranges_orig = self.feature_range
         else:  # compute the new ranges based on user input
             self.feature_range, feature_ranges_orig = self.data_interface.get_features_range(permitted_range)
+
         self.check_query_instance_validity(features_to_vary, permitted_range, query_instance, feature_ranges_orig)
 
         # check feature MAD validity and throw warnings
-        self.check_mad_validity(feature_weights)
+        self.data_interface.check_mad_validity(feature_weights)
 
         return features_to_vary
 
@@ -641,13 +645,6 @@ class ExplainerBase(ABC):
             for feature in self.data_interface.continuous_feature_names:
                 self.cont_minx.append(self.data_interface.permitted_range[feature][0])
                 self.cont_maxx.append(self.data_interface.permitted_range[feature][1])
-
-    def check_mad_validity(self, feature_weights):
-        """checks feature MAD validity and throw warnings.
-           TODO: add comments as to where this is used if this function is necessary, else remove.
-        """
-        if feature_weights == "inverse_mad":
-            self.data_interface.get_valid_mads(display_warnings=True, return_mads=False)
 
     def sigmoid(self, z):
         """This is used in VAE-based CF explainers."""

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -37,35 +37,27 @@ class TestPublicDataMethods:
 
 
 class DataTypeCombinations(Enum):
-    Incorrect = 1
-    AsNone = 2
+    Incorrect = 0
+    AsNone = 1
     Omitted = 2
 
 
-class TestErrorCasesPublicDataInterface:
+class TestErrorScenariosPublicDataInterface:
     @pytest.mark.parametrize('data_type', [DataTypeCombinations.Incorrect,
-                                           DataTypeCombinations.AsNone,
-                                           DataTypeCombinations.Omitted])
+                                           DataTypeCombinations.AsNone])
     def test_invalid_dataframe(self, data_type):
         iris = load_iris(as_frame=True)
         feature_names = iris.feature_names
         dataset = iris.frame
 
         if data_type == DataTypeCombinations.Incorrect:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(ValueError, match="should provide a pandas dataframe"):
                 dice_ml.Data(dataframe=dataset.values, continuous_features=feature_names,
                              outcome_name='target')
-            assert "should provide a pandas dataframe" in str(ve)
-        elif data_type == DataTypeCombinations.AsNone:
-            with pytest.raises(ValueError) as ve:
+        else:
+            with pytest.raises(ValueError, match="should provide a pandas dataframe"):
                 dice_ml.Data(dataframe=None, continuous_features=feature_names,
                              outcome_name='target')
-            assert "should provide a pandas dataframe" in str(ve)
-        else:
-            with pytest.raises(ValueError) as ve:
-                dice_ml.Data(continuous_features=feature_names,
-                             outcome_name='target')
-            assert "dataframe not found in params" in str(ve)
 
     @pytest.mark.parametrize('data_type', [DataTypeCombinations.Incorrect,
                                            DataTypeCombinations.AsNone,
@@ -75,22 +67,22 @@ class TestErrorCasesPublicDataInterface:
         dataset = iris.frame
 
         if data_type == DataTypeCombinations.Incorrect:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match="should provide the name(s) of continuous features in the data as a list"):
                 dice_ml.Data(dataframe=dataset, continuous_features=np.array(iris.feature_names),
                              outcome_name='target')
-
-            assert "should provide the name(s) of continuous features in the data as a list" in str(ve)
         elif data_type == DataTypeCombinations.AsNone:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match="should provide the name(s) of continuous features in the data as a list"):
                 dice_ml.Data(dataframe=dataset, continuous_features=None,
                              outcome_name='target')
-
-            assert "should provide the name(s) of continuous features in the data as a list" in str(ve)
         else:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match='continuous_features should be provided'):
                 dice_ml.Data(dataframe=dataset, outcome_name='target')
-
-            assert 'continuous_features should be provided' in str(ve)
 
     @pytest.mark.parametrize('data_type', [DataTypeCombinations.Incorrect,
                                            DataTypeCombinations.AsNone,
@@ -101,33 +93,33 @@ class TestErrorCasesPublicDataInterface:
         dataset = iris.frame
 
         if data_type == DataTypeCombinations.Incorrect:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match="should provide the name of outcome feature as a string"):
                 dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                              outcome_name=1)
-
-            assert "should provide the name of outcome feature as a string" in str(ve)
         elif data_type == DataTypeCombinations.AsNone:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match="should provide the name of outcome feature as a string"):
                 dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                              outcome_name=None)
-
-            assert "should provide the name of outcome feature as a string" in str(ve)
         else:
-            with pytest.raises(ValueError) as ve:
+            with pytest.raises(
+                    ValueError,
+                    match="should provide the name of outcome feature"):
                 dice_ml.Data(dataframe=dataset, continuous_features=feature_names)
-
-            assert "should provide the name of outcome feature" in str(ve)
 
     def test_not_found_outcome_name(self):
         iris = load_iris(as_frame=True)
         feature_names = iris.feature_names
         dataset = iris.frame
 
-        with pytest.raises(UserConfigValidationException) as ucve:
+        with pytest.raises(
+                UserConfigValidationException,
+                match="outcome_name invalid not found in"):
             dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                          outcome_name='invalid')
-
-        assert "outcome_name invalid not found in" in str(ucve)
 
     def test_unseen_continuous_feature_names(self):
         iris = load_iris(as_frame=True)
@@ -135,11 +127,11 @@ class TestErrorCasesPublicDataInterface:
         feature_names.append("new feature")
         dataset = iris.frame
 
-        with pytest.raises(UserConfigValidationException) as ucve:
+        with pytest.raises(
+                UserConfigValidationException,
+                match="continuous_features contains some feature names which are not part of columns in dataframe"):
             dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                          outcome_name='target')
-
-        assert "continuous_features contains some feature names which are not part of columns in dataframe" in str(ucve)
 
     def test_unseen_permitted_range(self):
         iris = load_iris(as_frame=True)
@@ -147,11 +139,11 @@ class TestErrorCasesPublicDataInterface:
         permitted_range = {'age': [45, 60]}
         dataset = iris.frame
 
-        with pytest.raises(UserConfigValidationException) as ucve:
+        with pytest.raises(
+                UserConfigValidationException,
+                match="permitted_range contains some feature names which are not part of columns in dataframe"):
             dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                          outcome_name='target', permitted_range=permitted_range)
-
-        assert "permitted_range contains some feature names which are not part of columns in dataframe" in str(ucve)
 
     def test_min_max_equal(self):
         dataset = helpers.load_min_max_equal_dataset()
@@ -164,13 +156,65 @@ class TestErrorCasesPublicDataInterface:
         continuous_features_precision = {'hours_per_week': 2}
         dataset = iris.frame
 
-        with pytest.raises(UserConfigValidationException) as ucve:
+        with pytest.raises(
+                UserConfigValidationException,
+                match="continuous_features_precision contains some feature names which"
+                      " are not part of columns in dataframe"):
             dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
                          outcome_name='target',
                          continuous_features_precision=continuous_features_precision)
 
-        assert "continuous_features_precision contains some feature names which" + \
-            " are not part of columns in dataframe" in str(ucve)
+
+class TestChecksPublicDataInterface:
+    @pytest.mark.parametrize('features_to_vary', ['all', None, ['not_a_feature']])
+    def test_check_features_to_vary(self, features_to_vary):
+        iris = load_iris(as_frame=True)
+        feature_names = iris.feature_names
+        dataset = iris.frame
+
+        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
+                                 outcome_name='target')
+
+        if features_to_vary is not None and features_to_vary != 'all':
+            with pytest.raises(
+                    UserConfigValidationException,
+                    match="Got features {" + "'not_a_feature'" + "} which are not present in training data"):
+                dice_data.check_features_to_vary(features_to_vary=features_to_vary)
+        else:
+            dice_data.check_features_to_vary(features_to_vary=features_to_vary)
+
+    @pytest.mark.parametrize('permitted_range', [None, {'not_a_feature': [20, 30]}])
+    def test_check_permitted_range_with_unknown_feature(self, permitted_range):
+        iris = load_iris(as_frame=True)
+        feature_names = iris.feature_names
+        dataset = iris.frame
+
+        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
+                                 outcome_name='target')
+
+        if permitted_range is not None:
+            with pytest.raises(
+                    UserConfigValidationException,
+                    match="Got features {" + "'not_a_feature'" + "} which are not present in training data"):
+                dice_data.check_permitted_range(permitted_range=permitted_range)
+        else:
+            dice_data.check_permitted_range(permitted_range=permitted_range)
+
+    def test_check_permitted_range_with_unknown_categorical_value(self):
+        iris = load_iris(as_frame=True)
+        permitted_range = {'new_feature': ['unknown_category']}
+        feature_names = iris.feature_names
+        dataset = iris.frame
+        dataset['new_feature'] = np.repeat(['known_category'], dataset.shape[0])
+
+        dice_data = dice_ml.Data(dataframe=dataset, continuous_features=feature_names,
+                                 outcome_name='target')
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match='The category {0} does not occur in the training data for feature {1}.'
+                      ' Allowed categories are {2}'.format('unknown_category', 'new_feature', ['known_category'])):
+            dice_data.check_permitted_range(permitted_range=permitted_range)
 
 
 class TestUserDataCorruption:

--- a/tests/test_data_interface/test_public_data_interface.py
+++ b/tests/test_data_interface/test_public_data_interface.py
@@ -67,17 +67,15 @@ class TestErrorScenariosPublicDataInterface:
         dataset = iris.frame
 
         if data_type == DataTypeCombinations.Incorrect:
-            with pytest.raises(
-                    ValueError,
-                    match="should provide the name(s) of continuous features in the data as a list"):
+            with pytest.raises(ValueError) as ve:
                 dice_ml.Data(dataframe=dataset, continuous_features=np.array(iris.feature_names),
                              outcome_name='target')
+            assert "should provide the name(s) of continuous features in the data as a list" in str(ve)
         elif data_type == DataTypeCombinations.AsNone:
-            with pytest.raises(
-                    ValueError,
-                    match="should provide the name(s) of continuous features in the data as a list"):
+            with pytest.raises(ValueError) as ve:
                 dice_ml.Data(dataframe=dataset, continuous_features=None,
                              outcome_name='target')
+            assert "should provide the name(s) of continuous features in the data as a list" in str(ve)
         else:
             with pytest.raises(
                     ValueError,
@@ -211,10 +209,11 @@ class TestChecksPublicDataInterface:
                                  outcome_name='target')
 
         with pytest.raises(
-                UserConfigValidationException,
-                match='The category {0} does not occur in the training data for feature {1}.'
-                      ' Allowed categories are {2}'.format('unknown_category', 'new_feature', ['known_category'])):
+                UserConfigValidationException) as ucve:
             dice_data.check_permitted_range(permitted_range=permitted_range)
+
+        assert 'The category {0} does not occur in the training data for feature {1}. Allowed categories are {2}'.format(
+            'unknown_category', 'new_feature', ['known_category']) in str(ucve)
 
 
 class TestUserDataCorruption:


### PR DESCRIPTION
1. If we do not have these validations, we go on to generate counterfactuals with the supplied values. The supplied values may not be in the original training data.
2. Moved some data_interface checks ipublic_data_interface.py.
3. Add the tests to test these checks

Signed-off-by: gaugup <gaugup@microsoft.com>