### PR TITLE
Extend categorical value check to numeric values

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -168,7 +168,8 @@ class ExplainerBase(ABC):
                 raise ValueError("Feature", feature, "not present in training data!")
 
         for feature in self.data_interface.categorical_feature_names:
-            if query_instance[feature].values[0] not in feature_ranges_orig[feature]:
+            if query_instance[feature].values[0] not in feature_ranges_orig[feature] and \
+                    str(query_instance[feature].values[0]) not in feature_ranges_orig[feature]:
                 raise ValueError("Feature", feature, "has a value outside the dataset.")
 
             if feature not in features_to_vary and permitted_range is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
-import pytest
 from collections import OrderedDict
 import pandas as pd
+import pytest
 from sklearn.datasets import load_iris, load_boston
 from sklearn.model_selection import train_test_split
+
 import dice_ml
 from dice_ml.utils import helpers
 
@@ -194,4 +195,6 @@ def create_boston_data():
     x_train, x_test, y_train, y_test = train_test_split(
         boston.data, boston.target,
         test_size=0.2, random_state=7)
-    return x_train, x_test, y_train, y_test, boston.feature_names
+    x_train = pd.DataFrame(data=x_train, columns=boston.feature_names)
+    x_test = pd.DataFrame(data=x_test, columns=boston.feature_names)
+    return x_train, x_test, y_train, y_test, boston.feature_names.tolist()


### PR DESCRIPTION
It seems if  user declares a numeric valued column as categorical, the dice-ml public_data_interface.py converts it into strings. However, at the time of CF generation, the value in the query instance of that feature is matched as is with the tring values which results in ValueError. 

The solution is the convert the feature value to string and compare against the learned categories.

Signed-off-by: gaugup <gaugup@microsoft.com>