### PR TITLE
Add documentation to save generated counterfactuals to disk

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,18 @@ Using DiCE, we can now generate examples that would have been classified as clas
   :width: 400
   :alt: List of counterfactual examples
 
+You can save the generated counterfactual examples in the following way:-
+
+.. code:: python
+
+    # Generate counterfactual examples
+    dice_exp = exp.generate_counterfactuals(query_instance, total_CFs=4, desired_class="opposite")
+    # Visualize counterfactual explanation
+    dice_exp.visualize_as_dataframe()
+    # Save generated counterfactual examples to disk
+    dice_exp.cf_examples_list[0].final_cfs_df.to_csv(path_or_buf='counterfactuals.csv', index=False)
+
+
 For more details, check out the `docs/source/notebooks <https://github.com/interpretml/DiCE/tree/master/docs/source/notebooks>`_ folder. Here are some example notebooks:
 
 * `Getting Started <https://github.com/interpretml/DiCE/blob/master/docs/source/notebooks/DiCE_getting_started.ipynb>`_: Generate CF examples for a `sklearn`, `tensorflow` or `pytorch` binary classifier and compute feature importance scores.


### PR DESCRIPTION
Seems like a significant dice-ml users request for some way to save the counterfactuals on disk as a .csv file. Hence adding some sample code to the project README.

Signed-off-by: gaugup <gaugup@microsoft.com>