### PR TITLE
Fix for logging

### DIFF
--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -9,7 +9,6 @@ import logging
 from dice_ml.data_interfaces.base_data_interface import _BaseData
 
 
-
 class PrivateData(_BaseData):
     """A data interface for private data with meta information."""
 

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -9,8 +9,6 @@ import logging
 from dice_ml.data_interfaces.base_data_interface import _BaseData
 
 
-logging.basicConfig(level=logging.NOTSET)
-
 
 class PrivateData(_BaseData):
     """A data interface for private data with meta information."""


### PR DESCRIPTION
Discovered via [an import of the `responsibleai` package](https://github.com/microsoft/responsible-ai-widgets/issues/850), a library package shouldn't call `logging.basicConfig()`. That logging call is [really only meant to be called once per process](https://docs.python.org/3/library/logging.html#logging.basicConfig):

> This function does nothing if the root logger already has handlers configured, unless the keyword argument force is set to True.

If a user calls `logging.basicConfig()` after `import dice_ml`, they probably aren't going to get the log messages they expect.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>