### PR TITLE
Add tests and classifier for python 3.10

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements-deeplearning.txt
+++ b/requirements-deeplearning.txt
@@ -1,2 +1,2 @@
 tensorflow>=1.13.0-rc1 
-torch
+torch; python_version < '3.10'

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,6 +4,7 @@ Adapted from the same code for the Microsoft DoWhy library.
 
 import os
 import subprocess
+import sys
 import tempfile
 
 import nbformat
@@ -16,7 +17,11 @@ advanced_notebooks = [
         "DiCE_with_advanced_options.ipynb",  # requires tensorflow 1.x
         "DiCE_getting_started_feasible.ipynb",  # needs changes after latest refactor
         "Benchmarking_different_CF_explanation_methods.ipynb"
-        ]
+]
+# notebooks that don't need to run on python 3.10
+torch_notebooks_not_3_10 = [
+    "DiCE_getting_started.ipynb"
+]
 
 # Adding the dice root folder to the python path so that jupyter notebooks
 if 'PYTHONPATH' not in os.environ:
@@ -73,6 +78,11 @@ def _notebook_run(filepath):
 parameter_list = []
 for nb in notebooks_list:
     if nb in advanced_notebooks:
+        param = pytest.param(
+            nb,
+            marks=[pytest.mark.skip, pytest.mark.advanced],
+            id=nb)
+    elif sys.version >= (3, 10) and nb in torch_notebooks_not_3_10:
         param = pytest.param(
             nb,
             marks=[pytest.mark.skip, pytest.mark.advanced],

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -82,7 +82,7 @@ for nb in notebooks_list:
             nb,
             marks=[pytest.mark.skip, pytest.mark.advanced],
             id=nb)
-    elif sys.version >= (3, 10) and nb in torch_notebooks_not_3_10:
+    elif sys.version_info >= (3, 10) and nb in torch_notebooks_not_3_10:
         param = pytest.param(
             nb,
             marks=[pytest.mark.skip, pytest.mark.advanced],


### PR DESCRIPTION
Add tests for python 3.10. We need to skip the notebooks that use torch models as there is no release for torch on 3.10. 

Signed-off-by: gaugup <gaugup@microsoft.com>