### PR TITLE
Cast desired_class to int() to fix counterfactual serialization

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -535,7 +535,7 @@ class ExplainerBase(ABC):
             self.target_cf_class = np.array(
                 [[self.infer_target_cfs_class(desired_class, test_pred, self.num_output_nodes)]],
                 dtype=np.float32)
-            desired_class = self.target_cf_class[0][0]
+            desired_class = int(self.target_cf_class[0][0])
             if self.target_cf_class == 0 and self.stopping_threshold > 0.5:
                 self.stopping_threshold = 0.25
             elif self.target_cf_class == 1 and self.stopping_threshold < 0.5:


### PR DESCRIPTION
It seems desired_class is cast to numpy.float32 which is not JSON serializable. Hence, casting the desired_class to int() to make sure that the to_json() on CounterfactualExplanation class is successful.

Signed-off-by: gaugup <gaugup@microsoft.com>