### PR TITLE
Remove torchvision from deeplearning dependencies

### DIFF
--- a/requirements-deeplearning.txt
+++ b/requirements-deeplearning.txt
@@ -1,3 +1,2 @@
 tensorflow>=1.13.0-rc1 
 torch
-torchvision


### PR DESCRIPTION
It seems torchvision is not used in any dice-ml module.