### PR TITLE
Add additional parameters to generate_counterfactuals() function

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -50,6 +50,8 @@ class ExplainerBase(ABC):
                                  desired_class="opposite", desired_range=None,
                                  permitted_range=None, features_to_vary="all",
                                  stopping_threshold=0.5, posthoc_sparsity_param=0.1,
+                                 proximity_weight=0.2, sparsity_weight=0.2, diversity_weight=5.0,
+                                 categorical_penalty=0.1,
                                  posthoc_sparsity_algorithm="linear", verbose=False, **kwargs):
         """General method for generating counterfactuals.
 
@@ -65,6 +67,11 @@ class ExplainerBase(ABC):
                                 If None, uses the parameters initialized in data_interface.
         :param features_to_vary: Either a string "all" or a list of feature names to vary.
         :param stopping_threshold: Minimum threshold for counterfactuals target class probability.
+        :param proximity_weight: A positive float. Larger this weight, more close the counterfactuals are to the
+                                 query_instance.
+        :param sparsity_weight: A positive float. Larger this weight, less features are changed from the query_instance.
+        :param diversity_weight: A positive float. Larger this weight, more diverse the counterfactuals are.
+        :param categorical_penalty: A positive float. A weight to ensure that all levels of a categorical variable sums to 1.
         :param posthoc_sparsity_param: Parameter for the post-hoc operation on continuous features to enhance sparsity.
         :param posthoc_sparsity_algorithm: Perform either linear or binary search. Takes "linear" or "binary".
                                            Prefer binary search when a feature range is large (for instance,

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -68,7 +68,8 @@ class ExplainerBase(ABC):
         :param features_to_vary: Either a string "all" or a list of feature names to vary.
         :param stopping_threshold: Minimum threshold for counterfactuals target class probability.
         :param proximity_weight: A positive float. Larger this weight, more close the counterfactuals are to the
-                                 query_instance. Used by ['genetic', 'gradientdescent'], ignored by ['random', 'kdtree'] methods.
+                                 query_instance. Used by ['genetic', 'gradientdescent'],
+                                 ignored by ['random', 'kdtree'] methods.
         :param sparsity_weight: A positive float. Larger this weight, less features are changed from the query_instance.
                                 Used by ['genetic', 'kdtree'], ignored by ['random', 'gradientdescent'] methods.
         :param diversity_weight: A positive float. Larger this weight, more diverse the counterfactuals are.

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -68,10 +68,13 @@ class ExplainerBase(ABC):
         :param features_to_vary: Either a string "all" or a list of feature names to vary.
         :param stopping_threshold: Minimum threshold for counterfactuals target class probability.
         :param proximity_weight: A positive float. Larger this weight, more close the counterfactuals are to the
-                                 query_instance.
+                                 query_instance. Used by ['genetic', 'gradientdescent'], ignored by ['random', 'kdtree'] methods.
         :param sparsity_weight: A positive float. Larger this weight, less features are changed from the query_instance.
+                                Used by ['genetic', 'kdtree'], ignored by ['random', 'gradientdescent'] methods.
         :param diversity_weight: A positive float. Larger this weight, more diverse the counterfactuals are.
+                                 Used by ['genetic', 'gradientdescent'], ignored by ['random', 'kdtree'] methods.
         :param categorical_penalty: A positive float. A weight to ensure that all levels of a categorical variable sums to 1.
+                                 Used by ['genetic', 'gradientdescent'], ignored by ['random', 'kdtree'] methods.
         :param posthoc_sparsity_param: Parameter for the post-hoc operation on continuous features to enhance sparsity.
         :param posthoc_sparsity_algorithm: Perform either linear or binary search. Takes "linear" or "binary".
                                            Prefer binary search when a feature range is large (for instance,

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -365,6 +365,9 @@ class TestExplainerBaseBinaryClassification:
         ans = exp.generate_counterfactuals(query_instances=sample_custom_query_2,
                                            features_to_vary='all',
                                            total_CFs=2, desired_class=desired_class,
+                                           proximity_weight=0.2, sparsity_weight=0.2,
+                                           diversity_weight=5.0,
+                                           categorical_penalty=0.1,
                                            permitted_range=None)
         if method != 'kdtree':
             assert all(ans.cf_examples_list[0].final_cfs_df[exp.data_interface.outcome_name].values == [desired_class] * 2)


### PR DESCRIPTION
It seems the generate_counterfactuals() method in dice_genetic.py support many more arguments than the ones supported in  generate_counterfactuals()  in explainer_base.py. Adding the additional parameters to generate_counterfactuals()  in explainer_base.py.

Signed-off-by: gaugup <gaugup@microsoft.com>