### PR TITLE
Update pythonpackage.yml to skip macos test for python 3.6

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest]
-
+        exclude:
+          - os: macos-latest
+            python-version: 3.6
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }} ${{ matrix.os }}


### PR DESCRIPTION
It seems that python 3.6 is not available on MAC now.

Run actions/setup-python@v1
Error: Version 3.[6](https://github.com/interpretml/DiCE/runs/5048471967?check_suite_focus=true#step:3:6) with arch x64 not found
Available versions:

3.10.2
3.[7]
3.[8]
3.[9]
