### PR TITLE
Update pythonpackage.yml to limit one test result upload and one code coverage upload

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
         pytest tests/ --durations=10 --doctest-modules --junitxml=junit/test-results.xml --cov=dice_ml --cov-report=xml --cov-report=html
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1
-      if: always()
+      if: ${{ (matrix.python-version == '3.8') && (matrix.os == 'ubuntu-latest') }}
       with:
         files: junit/test-results.xml
     - name: Upload coverage to Codecov

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,6 +49,7 @@ jobs:
         files: junit/test-results.xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
+      if: ${{ (matrix.python-version == '3.8') && (matrix.os == 'ubuntu-latest') }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: .


### PR DESCRIPTION
This fixes the issue where the python PR gate was failing during upload of unit test results for python 3.6. Now limiting test result upload and code coverage upload for linux build with python 3.8.