### PR TITLE
fix #46 - Implement steps limit for linear search

### DIFF
--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -48,7 +48,7 @@ class DiceKD(ExplainerBase):
                                   features_to_vary="all",
                                   permitted_range=None, sparsity_weight=1,
                                   feature_weights="inverse_mad", stopping_threshold=0.5, posthoc_sparsity_param=0.1,
-                                  posthoc_sparsity_algorithm="linear", verbose=False):
+                                  posthoc_sparsity_algorithm="linear", verbose=False, limit_steps_ls=10000):
         """Generates diverse counterfactual explanations
 
         :param query_instance: A dictionary of feature names and values. Test point of interest.
@@ -72,6 +72,7 @@ class DiceKD(ExplainerBase):
                                            varying from 10k to 1000k) and only if the features share a monotonic
                                            relationship with predicted outcome in the model.
         :param verbose: Parameter to determine whether to print 'Diverse Counterfactuals found!'
+        :param limit_steps_ls: Defines an upper limit for the linear search step in the posthoc_sparsity_enhancement
 
         :return: A CounterfactualExamples object to store and visualize the resulting counterfactual explanations
                  (see diverse_counterfactuals.py).
@@ -113,7 +114,9 @@ class DiceKD(ExplainerBase):
                                                               sparsity_weight,
                                                               stopping_threshold,
                                                               posthoc_sparsity_param,
-                                                              posthoc_sparsity_algorithm, verbose)
+                                                              posthoc_sparsity_algorithm,
+                                                              verbose,
+                                                              limit_steps_ls)
         self.cfs_preds = cfs_preds
 
         return exp.CounterfactualExamples(data_interface=self.data_interface,
@@ -214,7 +217,7 @@ class DiceKD(ExplainerBase):
     def find_counterfactuals(self, data_df_copy, query_instance, query_instance_orig, desired_range, desired_class,
                              total_CFs, features_to_vary, permitted_range,
                              sparsity_weight, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm,
-                             verbose):
+                             verbose, limit_steps_ls):
         """Finds counterfactuals by querying a K-D tree for the nearest data points in the desired class from the dataset."""
 
         start_time = timeit.default_timer()
@@ -239,7 +242,8 @@ class DiceKD(ExplainerBase):
                 self.final_cfs_df_sparse = copy.deepcopy(self.final_cfs)
                 self.final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(self.final_cfs_df_sparse, query_instance,
                                                                                 posthoc_sparsity_param,
-                                                                                posthoc_sparsity_algorithm)
+                                                                                posthoc_sparsity_algorithm,
+                                                                                limit_steps_ls)
             else:
                 self.final_cfs_df_sparse = None
         else:

--- a/dice_ml/explainer_interfaces/dice_pytorch.py
+++ b/dice_ml/explainer_interfaces/dice_pytorch.py
@@ -54,7 +54,7 @@ class DicePyTorch(ExplainerBase):
                                  feature_weights="inverse_mad", optimizer="pytorch:adam", learning_rate=0.05, min_iter=500,
                                  max_iter=5000, project_iter=0, loss_diff_thres=1e-5, loss_converge_maxiter=1, verbose=False,
                                  init_near_query_instance=True, tie_random=False, stopping_threshold=0.5,
-                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear"):
+                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear", limit_steps_ls=10000):
         """Generates diverse counterfactual explanations.
 
         :param query_instance: Test point of interest. A dictionary of feature names and values or a single row dataframe
@@ -94,6 +94,7 @@ class DicePyTorch(ExplainerBase):
                                            Prefer binary search when a feature range is large
                                            (for instance, income varying from 10k to 1000k) and only if the features
                                            share a monotonic relationship with predicted outcome in the model.
+        :param limit_steps_ls: Defines an upper limit for the linear search step in the posthoc_sparsity_enhancement
 
         :return: A CounterfactualExamples object to store and visualize the resulting
                  counterfactual explanations (see diverse_counterfactuals.py).
@@ -127,7 +128,7 @@ class DicePyTorch(ExplainerBase):
             self.find_counterfactuals(
                 query_instance, desired_class, optimizer, learning_rate, min_iter, max_iter,
                 project_iter, loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance,
-                tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
+                tie_random, stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm, limit_steps_ls)
 
         counterfactual_explanations = exp.CounterfactualExamples(
             data_interface=self.data_interface,
@@ -417,7 +418,7 @@ class DicePyTorch(ExplainerBase):
     def find_counterfactuals(self, query_instance, desired_class, optimizer, learning_rate, min_iter,
                              max_iter, project_iter, loss_diff_thres, loss_converge_maxiter, verbose,
                              init_near_query_instance, tie_random, stopping_threshold, posthoc_sparsity_param,
-                             posthoc_sparsity_algorithm):
+                             posthoc_sparsity_algorithm, limit_steps_ls):
         """Finds counterfactuals by gradient-descent."""
 
         # Prepares user defined query_instance for DiCE.
@@ -573,8 +574,11 @@ class DicePyTorch(ExplainerBase):
         # post-hoc operation on continuous features to enhance sparsity - only for public data
         if posthoc_sparsity_param is not None and posthoc_sparsity_param > 0 and 'data_df' in self.data_interface.__dict__:
             final_cfs_df_sparse = final_cfs_df.copy()
-            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(
-                final_cfs_df_sparse, test_instance_df, posthoc_sparsity_param, posthoc_sparsity_algorithm)
+            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(final_cfs_df_sparse,
+                                                                       test_instance_df,
+                                                                       posthoc_sparsity_param,
+                                                                       posthoc_sparsity_algorithm,
+                                                                       limit_steps_ls)
         else:
             final_cfs_df_sparse = None
 

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -39,7 +39,8 @@ class DiceRandom(ExplainerBase):
     def _generate_counterfactuals(self, query_instance, total_CFs, desired_range=None,
                                   desired_class="opposite", permitted_range=None,
                                   features_to_vary="all", stopping_threshold=0.5, posthoc_sparsity_param=0.1,
-                                  posthoc_sparsity_algorithm="linear", sample_size=1000, random_seed=None, verbose=False):
+                                  posthoc_sparsity_algorithm="linear", sample_size=1000, random_seed=None, verbose=False,
+                                  limit_steps_ls=10000):
         """Generate counterfactuals by randomly sampling features.
 
         :param query_instance: Test point of interest. A dictionary of feature names and values or a single row dataframe.
@@ -59,6 +60,7 @@ class DiceRandom(ExplainerBase):
                                            share a monotonic relationship with predicted outcome in the model.
         :param sample_size: Sampling size
         :param random_seed: Random seed for reproducibility
+        :param limit_steps_ls: Defines an upper limit for the linear search step in the posthoc_sparsity_enhancement
 
         :returns: A CounterfactualExamples object that contains the dataframe of generated counterfactuals as an attribute.
         """
@@ -168,8 +170,11 @@ class DiceRandom(ExplainerBase):
         if posthoc_sparsity_param is not None and posthoc_sparsity_param > 0 and \
                 self.final_cfs is not None and 'data_df' in self.data_interface.__dict__:
             final_cfs_df_sparse = final_cfs_df.copy()
-            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(
-                final_cfs_df_sparse, test_instance_df, posthoc_sparsity_param, posthoc_sparsity_algorithm)
+            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(final_cfs_df_sparse,
+                                                                       test_instance_df,
+                                                                       posthoc_sparsity_param,
+                                                                       posthoc_sparsity_algorithm,
+                                                                       limit_steps_ls)
         else:
             final_cfs_df_sparse = None
 

--- a/dice_ml/explainer_interfaces/dice_tensorflow1.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow1.py
@@ -70,7 +70,7 @@ class DiceTensorFlow1(ExplainerBase):
                                  optimizer="tensorflow:adam", learning_rate=0.05, min_iter=500, max_iter=5000,
                                  project_iter=0, loss_diff_thres=1e-5, loss_converge_maxiter=1, verbose=False,
                                  init_near_query_instance=True, tie_random=False, stopping_threshold=0.5,
-                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear"):
+                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear", limit_steps_ls=10000):
         """Generates diverse counterfactual explanations
 
         :param query_instance: Test point of interest. A dictionary of feature names and values or a single row dataframe.
@@ -113,6 +113,8 @@ class DiceTensorFlow1(ExplainerBase):
                                            Prefer binary search when a feature range is large
                                            (for instance, income varying from 10k to 1000k) and only if the features
                                            share a monotonic relationship with predicted outcome in the model.
+        :param limit_steps_ls: Defines an upper limit for the linear search step in the posthoc_sparsity_enhancement
+
 
         :return: A CounterfactualExamples object to store and visualize the resulting counterfactual explanations
                  (see diverse_counterfactuals.py).
@@ -159,7 +161,7 @@ class DiceTensorFlow1(ExplainerBase):
             self.update_hyperparameters(proximity_weight, diversity_weight, categorical_penalty)
 
         final_cfs_df, test_instance_df, final_cfs_df_sparse = self.find_counterfactuals(
-            query_instance, desired_class, learning_rate, min_iter, max_iter, project_iter,
+            query_instance, limit_steps_ls, desired_class, learning_rate, min_iter, max_iter, project_iter,
             loss_diff_thres, loss_converge_maxiter, verbose, init_near_query_instance, tie_random,
             stopping_threshold, posthoc_sparsity_param, posthoc_sparsity_algorithm)
 
@@ -520,7 +522,7 @@ class DiceTensorFlow1(ExplainerBase):
             self.loss_converge_iter = 0
             return False
 
-    def find_counterfactuals(self, query_instance, desired_class="opposite", learning_rate=0.05, min_iter=500,
+    def find_counterfactuals(self, query_instance, limit_steps_ls, desired_class="opposite", learning_rate=0.05, min_iter=500,
                              max_iter=5000, project_iter=0, loss_diff_thres=1e-5, loss_converge_maxiter=1,
                              verbose=False, init_near_query_instance=False, tie_random=False,
                              stopping_threshold=0.5, posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear"):
@@ -662,8 +664,11 @@ class DiceTensorFlow1(ExplainerBase):
         # post-hoc operation on continuous features to enhance sparsity - only for public data
         if posthoc_sparsity_param is not None and posthoc_sparsity_param > 0 and 'data_df' in self.data_interface.__dict__:
             final_cfs_df_sparse = final_cfs_df.copy()
-            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(
-                final_cfs_df_sparse, test_instance_df, posthoc_sparsity_param, posthoc_sparsity_algorithm)
+            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(final_cfs_df_sparse,
+                                                                       test_instance_df,
+                                                                       posthoc_sparsity_param,
+                                                                       posthoc_sparsity_algorithm,
+                                                                       limit_steps_ls)
         else:
             final_cfs_df_sparse = None
 

--- a/dice_ml/explainer_interfaces/dice_tensorflow2.py
+++ b/dice_ml/explainer_interfaces/dice_tensorflow2.py
@@ -56,7 +56,7 @@ class DiceTensorFlow2(ExplainerBase):
                                  optimizer="tensorflow:adam", learning_rate=0.05, min_iter=500, max_iter=5000,
                                  project_iter=0, loss_diff_thres=1e-5, loss_converge_maxiter=1, verbose=False,
                                  init_near_query_instance=True, tie_random=False, stopping_threshold=0.5,
-                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear"):
+                                 posthoc_sparsity_param=0.1, posthoc_sparsity_algorithm="linear", limit_steps_ls=10000):
         """Generates diverse counterfactual explanations
 
         :param query_instance: Test point of interest. A dictionary of feature names and values or a single row dataframe
@@ -98,6 +98,7 @@ class DiceTensorFlow2(ExplainerBase):
                                            Prefer binary search when a feature range is large
                                            (for instance, income varying from 10k to 1000k) and only if the features
                                            share a monotonic relationship with predicted outcome in the model.
+        :param limit_steps_ls: Defines an upper limit for the linear search step in the posthoc_sparsity_enhancement
 
         :return: A CounterfactualExamples object to store and visualize the resulting counterfactual explanations
                 (see diverse_counterfactuals.py).
@@ -133,7 +134,7 @@ class DiceTensorFlow2(ExplainerBase):
                                       learning_rate, min_iter, max_iter, project_iter,
                                       loss_diff_thres, loss_converge_maxiter, verbose,
                                       init_near_query_instance, tie_random, stopping_threshold,
-                                      posthoc_sparsity_param, posthoc_sparsity_algorithm)
+                                      posthoc_sparsity_param, posthoc_sparsity_algorithm, limit_steps_ls)
 
         counterfactual_explanations = exp.CounterfactualExamples(
             data_interface=self.data_interface,
@@ -420,7 +421,7 @@ class DiceTensorFlow2(ExplainerBase):
     def find_counterfactuals(self, query_instance, desired_class, optimizer, learning_rate, min_iter,
                              max_iter, project_iter, loss_diff_thres, loss_converge_maxiter, verbose,
                              init_near_query_instance, tie_random, stopping_threshold, posthoc_sparsity_param,
-                             posthoc_sparsity_algorithm):
+                             posthoc_sparsity_algorithm, limit_steps_ls):
         """Finds counterfactuals by gradient-descent."""
 
         # Prepares user defined query_instance for DiCE.
@@ -564,8 +565,11 @@ class DiceTensorFlow2(ExplainerBase):
         if posthoc_sparsity_param is not None and posthoc_sparsity_param > 0 and \
                 'data_df' in self.data_interface.__dict__:
             final_cfs_df_sparse = final_cfs_df.copy()
-            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(
-                final_cfs_df_sparse, test_instance_df, posthoc_sparsity_param, posthoc_sparsity_algorithm)
+            final_cfs_df_sparse = self.do_posthoc_sparsity_enhancement(final_cfs_df_sparse,
+                                                                       test_instance_df,
+                                                                       posthoc_sparsity_param,
+                                                                       posthoc_sparsity_algorithm,
+                                                                       limit_steps_ls)
         else:
             final_cfs_df_sparse = None
         # need to check the above code on posthoc sparsity


### PR DESCRIPTION
For some cases defined in issue #46, DiCE enters in an infinite loop because of very small changes in the do_linear_search function. This commit fixes that by adding an upper limit for linear search.