### PR TITLE
Raise user config validation exception when features_to_vary list is empty

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -58,6 +58,10 @@ class ExplainerBase(ABC):
             raise UserConfigValidationException(
                 "The number of counterfactuals generated per query instance (total_CFs) should be a positive integer.")
 
+        if features_to_vary != "all":
+            if len(features_to_vary) == 0:
+                raise UserConfigValidationException("Some features need to be varied for generating counterfactuals.")
+
         if posthoc_sparsity_algorithm not in _PostHocSparsityTypes.ALL:
             raise UserConfigValidationException(
                 'The posthoc_sparsity_algorithm should be {0} and not {1}'.format(

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -547,6 +547,12 @@ class TestExplainerBaseUserConfigValidations:
             explainer_function(query_instances=sample_custom_query_2,
                                total_CFs=10, desired_range=[0, 10])
 
+        with pytest.raises(
+                UserConfigValidationException,
+                match=r'Some features need to be varied for generating counterfactuals.'):
+            explainer_function(query_instances=sample_custom_query_2,
+                               total_CFs=10, features_to_vary=[])
+
     @pytest.mark.parametrize('explainer_function',
                              ['generate_counterfactuals', 'local_feature_importance',
                               'feature_importance', 'global_feature_importance'])
@@ -572,6 +578,9 @@ class TestExplainerBaseUserConfigValidations:
             explainer_function(query_instances=sample_custom_query_1,
                                total_CFs=10, desired_range=[4, 3])
 
+
+@pytest.mark.parametrize("method", ['random', 'genetic', 'kdtree'])
+class TestExplainerBaseDataValidations:
     def test_global_feature_importance_error_conditions_with_insufficient_query_points(
             self, method,
             sample_custom_query_1,
@@ -665,5 +674,3 @@ class TestExplainerBaseUserConfigValidations:
             exp.local_feature_importance(
                 query_instances=sample_custom_query_1,
                 total_CFs=1)
-
-# class TestExplainerBaseDataValidations:


### PR DESCRIPTION
This came up in testing that if the features_to_vary is empty list then the counterfactual computation fails eventually. Raising this as an exception condition.

Signed-off-by: Gaurav Gupta <gaugup@microsoft.com>