### PR TITLE
Fix #215 - Only convert original_pred if necessary

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -651,7 +651,13 @@ class ExplainerBase(ABC):
         """
         if desired_class_input == "opposite":
             if num_output_nodes == 2:
-                original_pred_1 = np.argmax(original_pred)
+                # 'original_pred' needs to be converted to the proper class if 'original_pred' comes from the
+                # 'predict_proba' method (length is 2 and class is index with maximum value). Otherwise 'original_pred'
+                # already contains the class.
+                if hasattr(original_pred, "__len__") and len(original_pred) > 1:
+                    original_pred_1 = np.argmax(original_pred)
+                else:
+                    original_pred_1 = original_pred
                 target_class = int(1 - original_pred_1)
                 return target_class
             elif num_output_nodes > 2:


### PR DESCRIPTION
Previously, ``original_pred`` was always converted from a class score vector to a class by taking the ``np.argmax`` in the function``infer_target_cfs_class``. This causes issues when ``original_pred`` is not a vector and already only contains the predicted class. In this case, ``original_pred`` is either a scalar or a size 1 array, for both of which ``np.argmax`` always returns 0. Therefore, in these cases the function always returns ``target_class = 1``, regardless of the original prediction.

I have fixed this by only converting ``original_pred`` when it is an array with a size greater than 1. The function must remain flexible for both vector-type ``original_pred`` and scalar-type ``original_pred`` because three classes (``dice_random``, ``dice_genetic`` and ``dice_kd``) depend on the function and all use different ways to represent the original prediction (class score vector vs size 1 array vs scalar).