### PR TITLE
Fix to unify type comparison methods

### DIFF
--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -17,7 +17,7 @@ class _BaseData(ABC):
         if 'outcome_name' not in params:
             raise ValueError("should provide the name of outcome feature")
 
-        if type(params['outcome_name']) is str:
+        if isinstance(params['outcome_name'] ,str):
             self.outcome_name = params['outcome_name']
         else:
             raise ValueError("should provide the name of outcome feature as a string")

--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -17,7 +17,7 @@ class _BaseData(ABC):
         if 'outcome_name' not in params:
             raise ValueError("should provide the name of outcome feature")
 
-        if isinstance(params['outcome_name'] ,str):
+        if isinstance(params['outcome_name'], str):
             self.outcome_name = params['outcome_name']
         else:
             raise ValueError("should provide the name of outcome feature as a string")

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -34,7 +34,7 @@ class PrivateData(_BaseData):
         """
         if sys.version_info > (3, 6, 0) and type(params['features']) in [dict, collections.OrderedDict]:
             features_dict = params['features']
-        elif sys.version_info <= (3, 6, 0) and type(params['features']) is collections.OrderedDict:
+        elif sys.version_info <= (3, 6, 0) and isinstance(params['features'], collections.OrderedDict):
             features_dict = params['features']
         else:
             raise ValueError(
@@ -51,7 +51,7 @@ class PrivateData(_BaseData):
         self.categorical_levels = {}
 
         for feature in features_dict:
-            if type(features_dict[feature][0]) is int:  # continuous feature
+            if isinstance(features_dict[feature][0] ,int):  # continuous feature
                 self.continuous_feature_names.append(feature)
                 self.permitted_range[feature] = features_dict[feature]
             else:

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -32,7 +32,7 @@ class PrivateData(_BaseData):
                                Default MAD value is 1 for all features.
         :param data_name (optional): Dataset name
         """
-        if sys.version_info > (3, 6, 0) and type(params['features']) in [dict, collections.OrderedDict]:
+        if sys.version_info > (3, 6, 0) and isinstance(params['features'], (dict, collections.OrderedDict)):
             features_dict = params['features']
         elif sys.version_info <= (3, 6, 0) and isinstance(params['features'], collections.OrderedDict):
             features_dict = params['features']

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -51,7 +51,7 @@ class PrivateData(_BaseData):
         self.categorical_levels = {}
 
         for feature in features_dict:
-            if isinstance(features_dict[feature][0] ,int):  # continuous feature
+            if isinstance(features_dict[feature][0], int):  # continuous feature
                 self.continuous_feature_names.append(feature)
                 self.permitted_range[feature] = features_dict[feature]
             else:

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -100,7 +100,7 @@ class PublicData(_BaseData):
         if 'continuous_features' not in params:
             raise ValueError('continuous_features should be provided')
 
-        if type(params['continuous_features']) is list:
+        if isinstance(params['continuous_features'], list):
             self.continuous_feature_names = params['continuous_features']
         else:
             raise ValueError(


### PR DESCRIPTION
This is a modification to unify the type comparison method.

Previously, there were two methods
- `if type(ABC) is str:`
- `if isinstance(ABC, str):`

This fix is related to coding and does not affect services. However, this unification is expected to increase code maintainability during development.

> Use isinstance() rather than type() for a typecheck.
> reference : https://pycodequ.al/docs/pylint-messages/c0123-unidiomatic-typecheck.html