### PR TITLE
Update requirements-test.txt to pin scikit-learn to below 1.1.2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,6 @@ pytest
 pytest-cov
 twine
 pytest-mock
+
+# Pin scikit-learn
+scikit-learn<1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jsonschema
 numpy # if you are using tensorflow 1.x, it requires numpy<=1.16 
 pandas
-scikit-learn
+scikit-learn<1.1.2
 h5py
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jsonschema
 numpy # if you are using tensorflow 1.x, it requires numpy<=1.16 
 pandas
-scikit-learn<1.1.2
+scikit-learn
 h5py
 tqdm


### PR DESCRIPTION
Seems like the newer release of scikit-learn 1.1.2 led to failure of PR gates. Hence pinning the scikit-learn to less than 1.1.2 in test dependencies. 

Signed-off-by: Gaurav Gupta <47334368+gaugup@users.noreply.github.com>