### PR TITLE
Fix variable name

### DIFF
--- a/dice_ml/explainer_interfaces/feasible_base_vae.py
+++ b/dice_ml/explainer_interfaces/feasible_base_vae.py
@@ -138,10 +138,10 @@ class FeasibleBaseVAE(ExplainerBase):
 
             train_dataset = torch.tensor(self.vae_train_feat).float()
             train_dataset = torch.utils.data.DataLoader(train_dataset, batch_size=self.batch_size, shuffle=True)
-            for train_x in enumerate(train_dataset):
+            for train in enumerate(train_dataset):
                 self.cf_vae_optimizer.zero_grad()
 
-                train_x = train_x[1]
+                train_x = train[1]
                 train_y = 1.0-torch.argmax(self.pred_model(train_x), dim=1)
                 train_size += train_x.shape[0]
 

--- a/dice_ml/explainer_interfaces/feasible_model_approx.py
+++ b/dice_ml/explainer_interfaces/feasible_model_approx.py
@@ -83,10 +83,10 @@ class FeasibleModelApprox(FeasibleBaseVAE, ExplainerBase):
 
             train_dataset = torch.tensor(self.vae_train_feat).float()
             train_dataset = torch.utils.data.DataLoader(train_dataset, batch_size=self.batch_size, shuffle=True)
-            for train_x in enumerate(train_dataset):
+            for train in enumerate(train_dataset):
                 self.cf_vae_optimizer.zero_grad()
 
-                train_x = train_x[1]
+                train_x = train[1]
                 train_y = 1.0-torch.argmax(self.pred_model(train_x), dim=1)
                 train_size += train_x.shape[0]
 


### PR DESCRIPTION
Signed-off-by: Daiki Katsuragawa <50144563+daikikatsuragawa@users.noreply.github.com>

--

As part of #331, the verification detected mypy error other than a type hint. This occurs when the variable name `train_x` is used as a variable of another type. Fortunately, there is no other place where this error occurs. Since this is not the intent of #331, we have created a pull request on its own. The command and output that detected this error is as follows.

```sh
mypy --ignore-missing-imports --disallow-untyped-def dice_ml/
```

```sh

(skip)

dice_ml/explainer_interfaces/feasible_model_approx.py:110: error: No overload variant of "__getitem__" of "tuple" matches argument type "Tuple[slice, Any]"
dice_ml/explainer_interfaces/feasible_model_approx.py:110: note: Possible overload variants:
dice_ml/explainer_interfaces/feasible_model_approx.py:110: note:     def __getitem__(self, SupportsIndex) -> Any
dice_ml/explainer_interfaces/feasible_model_approx.py:110: note:     def __getitem__(self, slice) -> Tuple[Any, ...]
dice_ml/explainer_interfaces/feasible_model_approx.py:115: error: No overload variant of "__getitem__" of "tuple" matches argument type "Tuple[slice, Any]"
dice_ml/explainer_interfaces/feasible_model_approx.py:115: note: Possible overload variants:
dice_ml/explainer_interfaces/feasible_model_approx.py:115: note:     def __getitem__(self, SupportsIndex) -> Any
dice_ml/explainer_interfaces/feasible_model_approx.py:115: note:     def __getitem__(self, slice) -> Tuple[Any, ...]
```