### PR TITLE
Update requirements.txt to remove h5py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,5 @@ dependencies:
   - numpy
   - scikit-learn
   - pandas
-  - h5py
   - jsonschema
   - tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ jsonschema
 numpy # if you are using tensorflow 1.x, it requires numpy<=1.16 
 pandas
 scikit-learn
-h5py
 tqdm


### PR DESCRIPTION
It seems like h5py is not used as a required package in dice-ml.

Signed-off-by: Gaurav Gupta <47334368+gaugup@users.noreply.github.com>