### PR TITLE
Updated display_df and print_list to use isclose for show_only_changes

### DIFF
--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -1,9 +1,8 @@
 import copy
 import json
+import math
 
 import pandas as pd
-
-import math
 
 from dice_ml.constants import ModelTypes, _SchemaVersions
 from dice_ml.utils.serialize import DummyDataInterface

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -3,6 +3,8 @@ import json
 
 import pandas as pd
 
+import math
+
 from dice_ml.constants import ModelTypes, _SchemaVersions
 from dice_ml.utils.serialize import DummyDataInterface
 
@@ -134,7 +136,7 @@ class CounterfactualExamples:
             org = self.test_instance_df.values.tolist()[0]
             for ix in range(df.shape[0]):
                 for jx in range(len(org)):
-                    if newdf[ix][jx] == org[jx]:
+                    if math.isclose(newdf[ix][jx] == org[jx], rel_tol=org[jx]/10000):
                         newdf[ix][jx] = '-'
                     else:
                         newdf[ix][jx] = str(newdf[ix][jx])
@@ -157,7 +159,7 @@ class CounterfactualExamples:
             org = self.test_instance_df.values.tolist()[0]
             for ix in range(len(newli)):
                 for jx in range(len(newli[ix])):
-                    if newli[ix][jx] == org[jx]:
+                    if math.isclose(newli[ix][jx], org[jx], rel_tol=org[jx]/10000):
                         newli[ix][jx] = '-'
                 print(newli[ix])
 


### PR DESCRIPTION
Previously, `show_only_changes `used direct equality, resulting in all values flagging as changed incorrectly.

This change updates CounterfactualExamples to use `math.isclose` to generate both the lists and displayed dataframes when `show_only_changes=True` 