### PR TITLE
Update codecov-action@v2 to codecov-action@v3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         files: junit/test-results.xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       if: ${{ (matrix.python-version == '3.8') && (matrix.os == 'ubuntu-latest') }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This helps resolve the following warning:-

![image](https://github.com/interpretml/DiCE/assets/47334368/a437443a-83f6-4d94-b72a-4ce15d7ae9ec)
