### PR TITLE
Change logic to get the adult dataset

### DIFF
--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -4,6 +4,8 @@ This module containts helper functions to load data and get meta deta.
 import os
 import pickle
 import shutil
+import zipfile
+from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
@@ -22,8 +24,14 @@ def load_adult_income_dataset(only_train=True):
 
     :return adult_data: returns preprocessed adult income dataset.
     """
-    # some test
-    raw_data = np.genfromtxt('https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data',
+    # Download the adult dataset from https://archive.ics.uci.edu/static/public/2/adult.zip as a zip folder
+    outdirname = 'adult'
+    zipfilename = outdirname + '.zip'
+    urlretrieve('https://archive.ics.uci.edu/static/public/2/adult.zip', zipfilename)
+    with zipfile.ZipFile(zipfilename, 'r') as unzip:
+        unzip.extractall(outdirname)
+
+    raw_data = np.genfromtxt(outdirname + '/adult.data',
                              delimiter=', ', dtype=str, invalid_raise=False)
 
     #  column names from "https://archive.ics.uci.edu/ml/datasets/Adult"
@@ -82,8 +90,8 @@ def load_adult_income_dataset(only_train=True):
         adult_data = train.reset_index(drop=True)
 
     # Remove the downloaded dataset
-    if os.path.isdir('archive.ics.uci.edu'):
-        entire_path = os.path.abspath('archive.ics.uci.edu')
+    if os.path.isdir(outdirname):
+        entire_path = os.path.abspath(outdirname)
         shutil.rmtree(entire_path)
 
     return adult_data

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -22,6 +22,7 @@ def load_adult_income_dataset(only_train=True):
 
     :return adult_data: returns preprocessed adult income dataset.
     """
+    # some test
     raw_data = np.genfromtxt('https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data',
                              delimiter=', ', dtype=str, invalid_raise=False)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+from dice_ml.utils.helpers import load_adult_income_dataset
+
+
+class TestHelpers:
+    def test_load_adult_income_dataset(self):
+        adult_data = load_adult_income_dataset()
+        assert adult_data is not None
+        assert isinstance(adult_data, pd.DataFrame)


### PR DESCRIPTION
Looks like the URL https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data gives 404. The URL that works is https://archive.ics.uci.edu/static/public/2/adult.zip.