### PR TITLE
Return original class labels without encoding

### DIFF
--- a/dice_ml/counterfactual_explanations.py
+++ b/dice_ml/counterfactual_explanations.py
@@ -158,6 +158,7 @@ class CounterfactualExplanations:
             desired_class = None
             desired_range = None
             for cf_examples in self.cf_examples_list:
+                print(cf_examples)
                 cf_examples_str = cf_examples.to_json(
                     serialization_version=serialization_version)
                 # We need to load the json again since we need to decompose the

--- a/dice_ml/counterfactual_explanations.py
+++ b/dice_ml/counterfactual_explanations.py
@@ -158,7 +158,6 @@ class CounterfactualExplanations:
             desired_class = None
             desired_range = None
             for cf_examples in self.cf_examples_list:
-                print(cf_examples)
                 cf_examples_str = cf_examples.to_json(
                     serialization_version=serialization_version)
                 # We need to load the json again since we need to decompose the

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -1,7 +1,8 @@
 import copy
 import json
-import numpy as np
 import math
+
+import numpy as np
 import pandas as pd
 
 from dice_ml.constants import ModelTypes, _SchemaVersions
@@ -37,6 +38,7 @@ def json_converter(obj):
         if isinstance(obj, np.generic):
             return obj.item()
         return obj.__dict__
+
 
 class CounterfactualExamples:
     """A class to store and visualize the resulting counterfactual explanations."""

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -1,7 +1,7 @@
+import copy
 import json
 
 import pandas as pd
-
 from dice_ml.constants import ModelTypes, _SchemaVersions
 from dice_ml.utils.serialize import DummyDataInterface
 
@@ -97,7 +97,8 @@ class CounterfactualExamples:
             elif hasattr(self.data_interface, 'data_df') and \
                     display_sparse_df is True and self.final_cfs_df_sparse is None:
                 print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. ',
-                      'displaying Diverse Counterfactual set without sparsity correction (new outcome : {})'.format(self.new_outcome))
+                      'displaying Diverse Counterfactual set without',
+                      'sparsity correction (new outcome : {})'.format(self.new_outcome))
                 self._dump_output(content=self.final_cfs_df, show_only_changes=show_only_changes,
                                   is_notebook_console=is_notebook_console)
             elif not hasattr(self.data_interface, 'data_df'):  # for private data

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -1,4 +1,3 @@
-import copy
 import json
 
 import pandas as pd
@@ -98,13 +97,12 @@ class CounterfactualExamples:
             elif hasattr(self.data_interface, 'data_df') and \
                     display_sparse_df is True and self.final_cfs_df_sparse is None:
                 print('\nPlease specify a valid posthoc_sparsity_param to perform sparsity correction.. ',
-                      'displaying Diverse Counterfactual set without sparsity correction (new outcome : %i)' %
-                      (self.new_outcome))
+                      'displaying Diverse Counterfactual set without sparsity correction (new outcome : {})'.format(self.new_outcome))
                 self._dump_output(content=self.final_cfs_df, show_only_changes=show_only_changes,
                                   is_notebook_console=is_notebook_console)
             elif not hasattr(self.data_interface, 'data_df'):  # for private data
                 print('\nDiverse Counterfactual set without sparsity correction since only metadata about each',
-                      ' feature is available (new outcome: %i)' % (self.new_outcome))
+                      ' feature is available (new outcome: {}'.format(self.new_outcome))
                 self._dump_output(content=self.final_cfs_df, show_only_changes=show_only_changes,
                                   is_notebook_console=is_notebook_console)
             else:
@@ -119,7 +117,7 @@ class CounterfactualExamples:
         from IPython.display import display
 
         # original instance
-        print('Query instance (original outcome : %i)' % round(self.test_pred))
+        print('Query instance (original outcome : {0})'.format(self.test_pred))
         display(self.test_instance_df)  # works only in Jupyter notebook
         self._visualize_internal(display_sparse_df=display_sparse_df,
                                  show_only_changes=show_only_changes,
@@ -142,7 +140,7 @@ class CounterfactualExamples:
 
     def visualize_as_list(self, display_sparse_df=True, show_only_changes=False):
         # original instance
-        print('Query instance (original outcome : %i)' % round(self.test_pred))
+        print('Query instance (original outcome : {})'.format(self.test_pred))
         print(self.test_instance_df.values.tolist()[0])
         self._visualize_internal(display_sparse_df=display_sparse_df,
                                  show_only_changes=show_only_changes,

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -1,6 +1,6 @@
 import copy
 import json
-
+import numpy as np
 import pandas as pd
 
 from dice_ml.constants import ModelTypes, _SchemaVersions
@@ -33,8 +33,9 @@ def json_converter(obj):
     try:
         return obj.to_json()
     except AttributeError:
+        if isinstance(obj, np.generic):
+            return obj.item()
         return obj.__dict__
-
 
 class CounterfactualExamples:
     """A class to store and visualize the resulting counterfactual explanations."""
@@ -207,7 +208,7 @@ class CounterfactualExamples:
                 _DiverseCFV2SchemaConstants.DESIRED_CLASS: self.desired_class,
                 _DiverseCFV2SchemaConstants.DESIRED_RANGE: self.desired_range
             }
-            return json.dumps(alternate_obj)
+            return json.dumps(alternate_obj, default=json_converter)
 
     @staticmethod
     def from_json(cf_example_json_str):

--- a/dice_ml/diverse_counterfactuals.py
+++ b/dice_ml/diverse_counterfactuals.py
@@ -2,6 +2,7 @@ import copy
 import json
 
 import pandas as pd
+
 from dice_ml.constants import ModelTypes, _SchemaVersions
 from dice_ml.utils.serialize import DummyDataInterface
 

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -122,11 +122,14 @@ class DiceKD(ExplainerBase):
                                                               limit_steps_ls)
         self.cfs_preds = cfs_preds
         # Decoding the output label back to original data type (e.g., str labels)
-        query_instance[self.data_interface.outcome_name] = self.decode_model_output(query_instance[self.data_interface.outcome_name])
+        query_instance[self.data_interface.outcome_name] = \
+            self.decode_model_output(query_instance[self.data_interface.outcome_name])
         if self.final_cfs_df is not None:
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df[self.data_interface.outcome_name] = self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
-            self.final_cfs_df_sparse[self.data_interface.outcome_name] = self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
+            self.final_cfs_df[self.data_interface.outcome_name] = \
+                self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
+            self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
+                self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           final_cfs_df=self.final_cfs_df,
                                           test_instance_df=query_instance,

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -131,7 +131,8 @@ class DiceKD(ExplainerBase):
             if self.final_cfs_df_sparse is not None:
                 self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
                     self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
-        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] if hasattr(self, 'target_cf_class')  else desired_class
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] \
+            if hasattr(self, 'target_cf_class') else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           final_cfs_df=self.final_cfs_df,
                                           test_instance_df=query_instance,

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -123,7 +123,7 @@ class DiceKD(ExplainerBase):
         self.cfs_preds = cfs_preds
         if self.final_cfs_df is not None:
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
-        
+
         # decoding to original label
         query_instance, self.final_cfs_df, self.final_cfs_df_sparse = \
             self.decode_to_original_labels(query_instance, self.final_cfs_df, self.final_cfs_df_sparse)

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -121,16 +121,12 @@ class DiceKD(ExplainerBase):
                                                               verbose,
                                                               limit_steps_ls)
         self.cfs_preds = cfs_preds
-        # Decoding the output label back to original data type (e.g., str labels)
-        query_instance[self.data_interface.outcome_name] = \
-            self.decode_model_output(query_instance[self.data_interface.outcome_name])
         if self.final_cfs_df is not None:
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df[self.data_interface.outcome_name] = \
-                self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
-            if self.final_cfs_df_sparse is not None:
-                self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
-                    self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
+        
+        # decoding to original label
+        query_instance, self.final_cfs_df, self.final_cfs_df_sparse = \
+            self.decode_to_original_labels(query_instance, self.final_cfs_df, self.final_cfs_df_sparse)
         desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] \
             if hasattr(self, 'target_cf_class') else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,

--- a/dice_ml/explainer_interfaces/dice_KD.py
+++ b/dice_ml/explainer_interfaces/dice_KD.py
@@ -128,15 +128,17 @@ class DiceKD(ExplainerBase):
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
             self.final_cfs_df[self.data_interface.outcome_name] = \
                 self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
-            self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
-                self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
+            if self.final_cfs_df_sparse is not None:
+                self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
+                    self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] if hasattr(self, 'target_cf_class')  else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           final_cfs_df=self.final_cfs_df,
                                           test_instance_df=query_instance,
                                           final_cfs_df_sparse=self.final_cfs_df_sparse,
                                           posthoc_sparsity_param=posthoc_sparsity_param,
                                           desired_range=desired_range,
-                                          desired_class=self.decode_model_output(pd.Series(self.target_cf_class[0]))[0],
+                                          desired_class=desired_class_param,
                                           model_type=self.model.model_type)
 
     def predict_fn_scores(self, input_instance):

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -292,7 +292,8 @@ class DiceGenetic(ExplainerBase):
         query_instance_df = self.find_counterfactuals(query_instance, desired_range, desired_class, features_to_vary,
                                                       maxiterations, thresh, verbose)
 
-        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] if hasattr(self, 'target_cf_class')  else desired_class
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] \
+            if hasattr(self, 'target_cf_class') else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           test_instance_df=query_instance_df,
                                           final_cfs_df=self.final_cfs_df,

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -509,19 +509,17 @@ class DiceGenetic(ExplainerBase):
         # converting to dataframe
         query_instance_df = self.label_decode(query_instance)
         query_instance_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.test_pred)
-        query_instance_df[self.data_interface.outcome_name] = \
-            self.decode_model_output(query_instance_df[self.data_interface.outcome_name])
         self.final_cfs_df = self.label_decode_cfs(self.final_cfs)
         self.final_cfs_df_sparse = copy.deepcopy(self.final_cfs_df)
 
         if self.final_cfs_df is not None:
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df[self.data_interface.outcome_name] = \
-                self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
             self.final_cfs_df_sparse[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
-                self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
             self.round_to_precision()
+
+        # decoding to original label
+        query_instance_df, self.final_cfs_df, self.final_cfs_df_sparse = \
+            self.decode_to_original_labels(query_instance_df, self.final_cfs_df, self.final_cfs_df_sparse)
 
         self.elapsed = timeit.default_timer() - self.start_time
         m, s = divmod(self.elapsed, 60)

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -292,13 +292,14 @@ class DiceGenetic(ExplainerBase):
         query_instance_df = self.find_counterfactuals(query_instance, desired_range, desired_class, features_to_vary,
                                                       maxiterations, thresh, verbose)
 
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class[0]))[0] if hasattr(self, 'target_cf_class')  else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           test_instance_df=query_instance_df,
                                           final_cfs_df=self.final_cfs_df,
                                           final_cfs_df_sparse=self.final_cfs_df_sparse,
                                           posthoc_sparsity_param=posthoc_sparsity_param,
                                           desired_range=desired_range,
-                                          desired_class=self.decode_model_output(pd.Series(self.target_cf_class[0]))[0],
+                                          desired_class=desired_class_param,
                                           model_type=self.model.model_type)
 
     def predict_fn_scores(self, input_instance):

--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -507,15 +507,18 @@ class DiceGenetic(ExplainerBase):
         # converting to dataframe
         query_instance_df = self.label_decode(query_instance)
         query_instance_df[self.data_interface.outcome_name] = self.get_model_output_from_scores(self.test_pred)
-        query_instance_df[self.data_interface.outcome_name] = self.decode_model_output(query_instance_df[self.data_interface.outcome_name])
+        query_instance_df[self.data_interface.outcome_name] = \
+            self.decode_model_output(query_instance_df[self.data_interface.outcome_name])
         self.final_cfs_df = self.label_decode_cfs(self.final_cfs)
         self.final_cfs_df_sparse = copy.deepcopy(self.final_cfs_df)
 
         if self.final_cfs_df is not None:
             self.final_cfs_df[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df[self.data_interface.outcome_name] = self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
+            self.final_cfs_df[self.data_interface.outcome_name] = \
+                self.decode_model_output(self.final_cfs_df[self.data_interface.outcome_name])
             self.final_cfs_df_sparse[self.data_interface.outcome_name] = self.cfs_preds
-            self.final_cfs_df_sparse[self.data_interface.outcome_name] = self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
+            self.final_cfs_df_sparse[self.data_interface.outcome_name] = \
+                self.decode_model_output(self.final_cfs_df_sparse[self.data_interface.outcome_name])
             self.round_to_precision()
 
         self.elapsed = timeit.default_timer() - self.start_time

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -199,8 +199,9 @@ class DiceRandom(ExplainerBase):
                 print('Only %d (required %d) ' % (self.total_cfs_found, self.total_CFs),
                       'Diverse Counterfactuals found for the given configuration, perhaps try with different parameters...',
                       '; total time taken: %02d' % m, 'min %02d' % s, 'sec')
-        
-        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class))[0] if hasattr(self, 'target_cf_class') else desired_class
+
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class))[0] \
+            if hasattr(self, 'target_cf_class') else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           final_cfs_df=final_cfs_df,
                                           test_instance_df=test_instance_df,

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -180,7 +180,11 @@ class DiceRandom(ExplainerBase):
 
         self.elapsed = timeit.default_timer() - start_time
         m, s = divmod(self.elapsed, 60)
+        # decoding to original label 
+        test_instance_df[self.data_interface.outcome_name] = self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
         if self.valid_cfs_found:
+            final_cfs_df[self.data_interface.outcome_name] = self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
+            final_cfs_df_sparse[self.data_interface.outcome_name] = self.decode_model_output(final_cfs_df_sparse[self.data_interface.outcome_name])
             if verbose:
                 print('Diverse Counterfactuals found! total time taken: %02d' %
                       m, 'min %02d' % s, 'sec')
@@ -198,7 +202,7 @@ class DiceRandom(ExplainerBase):
                                           test_instance_df=test_instance_df,
                                           final_cfs_df_sparse=final_cfs_df_sparse,
                                           posthoc_sparsity_param=posthoc_sparsity_param,
-                                          desired_class=desired_class,
+                                          desired_class=self.decode_model_output(pd.Series(self.target_cf_class))[0],
                                           desired_range=desired_range,
                                           model_type=self.model.model_type)
 

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -180,14 +180,11 @@ class DiceRandom(ExplainerBase):
 
         self.elapsed = timeit.default_timer() - start_time
         m, s = divmod(self.elapsed, 60)
+
         # decoding to original label
-        test_instance_df[self.data_interface.outcome_name] = \
-            self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
+        test_instance_df, final_cfs_df, final_cfs_df_sparse = \
+            self.decode_to_original_labels(test_instance_df, final_cfs_df, final_cfs_df_sparse)
         if final_cfs_df is not None:
-            final_cfs_df[self.data_interface.outcome_name] = \
-                self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
-            final_cfs_df_sparse[self.data_interface.outcome_name] = \
-                self.decode_model_output(final_cfs_df_sparse[self.data_interface.outcome_name])
             if verbose:
                 print('Diverse Counterfactuals found! total time taken: %02d' %
                       m, 'min %02d' % s, 'sec')

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -183,7 +183,7 @@ class DiceRandom(ExplainerBase):
         # decoding to original label
         test_instance_df[self.data_interface.outcome_name] = \
             self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
-        if self.valid_cfs_found:
+        if final_cfs_df is not None:
             final_cfs_df[self.data_interface.outcome_name] = \
                 self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
             final_cfs_df_sparse[self.data_interface.outcome_name] = \
@@ -199,13 +199,14 @@ class DiceRandom(ExplainerBase):
                 print('Only %d (required %d) ' % (self.total_cfs_found, self.total_CFs),
                       'Diverse Counterfactuals found for the given configuration, perhaps try with different parameters...',
                       '; total time taken: %02d' % m, 'min %02d' % s, 'sec')
-
+        
+        desired_class_param = self.decode_model_output(pd.Series(self.target_cf_class))[0] if hasattr(self, 'target_cf_class') else desired_class
         return exp.CounterfactualExamples(data_interface=self.data_interface,
                                           final_cfs_df=final_cfs_df,
                                           test_instance_df=test_instance_df,
                                           final_cfs_df_sparse=final_cfs_df_sparse,
                                           posthoc_sparsity_param=posthoc_sparsity_param,
-                                          desired_class=self.decode_model_output(pd.Series(self.target_cf_class))[0],
+                                          desired_class=desired_class_param,
                                           desired_range=desired_range,
                                           model_type=self.model.model_type)
 

--- a/dice_ml/explainer_interfaces/dice_random.py
+++ b/dice_ml/explainer_interfaces/dice_random.py
@@ -180,11 +180,14 @@ class DiceRandom(ExplainerBase):
 
         self.elapsed = timeit.default_timer() - start_time
         m, s = divmod(self.elapsed, 60)
-        # decoding to original label 
-        test_instance_df[self.data_interface.outcome_name] = self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
+        # decoding to original label
+        test_instance_df[self.data_interface.outcome_name] = \
+            self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
         if self.valid_cfs_found:
-            final_cfs_df[self.data_interface.outcome_name] = self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
-            final_cfs_df_sparse[self.data_interface.outcome_name] = self.decode_model_output(final_cfs_df_sparse[self.data_interface.outcome_name])
+            final_cfs_df[self.data_interface.outcome_name] = \
+                self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
+            final_cfs_df_sparse[self.data_interface.outcome_name] = \
+                self.decode_model_output(final_cfs_df_sparse[self.data_interface.outcome_name])
             if verbose:
                 print('Diverse Counterfactuals found! total time taken: %02d' %
                       m, 'min %02d' % s, 'sec')

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -758,10 +758,10 @@ class ExplainerBase(ABC):
 
     def decode_model_output(self, encoded_labels):
         if self.model.model_type == ModelTypes.Classifier:
-            if hasattr(self.model.model, "classes_"): # sklearn model
+            if hasattr(self.model.model, "classes_"):  # sklearn model
                 label_dict = {idx: label for idx, label in enumerate(self.model.model.classes_)}
                 return encoded_labels.apply(lambda x: label_dict[x])
-        return encoded_labels # no op
+        return encoded_labels  # no op
 
     def get_model_output_from_scores(self, model_scores):
         if self.model.model_type == ModelTypes.Classifier:

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -873,7 +873,7 @@ class ExplainerBase(ABC):
         if no_cf_generated:
             raise UserConfigValidationException(
                 "No counterfactuals found for any of the query points! Kindly check your configuration.")
-    
+
     def decode_to_original_labels(self, test_instance_df, final_cfs_df, final_cfs_df_sparse):
         test_instance_df[self.data_interface.outcome_name] = \
             self.decode_model_output(test_instance_df[self.data_interface.outcome_name])

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -873,6 +873,17 @@ class ExplainerBase(ABC):
         if no_cf_generated:
             raise UserConfigValidationException(
                 "No counterfactuals found for any of the query points! Kindly check your configuration.")
+    
+    def decode_to_original_labels(self, test_instance_df, final_cfs_df, final_cfs_df_sparse):
+        test_instance_df[self.data_interface.outcome_name] = \
+            self.decode_model_output(test_instance_df[self.data_interface.outcome_name])
+        if final_cfs_df is not None:
+            final_cfs_df[self.data_interface.outcome_name] = \
+                self.decode_model_output(final_cfs_df[self.data_interface.outcome_name])
+            if final_cfs_df_sparse is not None:
+                final_cfs_df_sparse[self.data_interface.outcome_name] = \
+                    self.decode_model_output(final_cfs_df_sparse[self.data_interface.outcome_name])
+        return test_instance_df, final_cfs_df, final_cfs_df_sparse
 
     def serialize_explainer(self, path):
         """Serialize the explainer to the file specified by path."""

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -141,6 +141,7 @@ def load_custom_testing_dataset_binary():
     data = [['a', 1, 0], ['b', 5, 1], ['c', 2, 0], ['a', 3, 0], ['c', 4, 1]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
+
 def load_custom_testing_dataset_binary_str():
     data = [
         ["a", 1, "zero"],
@@ -150,6 +151,7 @@ def load_custom_testing_dataset_binary_str():
         ["c", 4, "one"],
     ]
     return pd.DataFrame(data, columns=["Categorical", "Numerical", "Outcome"])
+
 
 def load_custom_testing_dataset_multiclass():
     data = [['a', 10, 1], ['b', 20, 2], ['c', 14, 1], ['a', 23, 2], ['c', 7, 0]]

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -158,6 +158,17 @@ def load_custom_testing_dataset_multiclass():
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
 
+def load_custom_testing_dataset_multiclass_str():
+    data = [
+        ["a", 1, "zero"],
+        ["b", 5, "one"],
+        ["c", 2, "two"],
+        ["a", 3, "one"],
+        ["c", 4, "zero"],
+    ]
+    return pd.DataFrame(data, columns=["Categorical", "Numerical", "Outcome"])
+
+
 def load_custom_testing_dataset_regression():
     data = [['a', 10, 1], ['b', 21, 2.1], ['c', 14, 1.4], ['a', 23, 2.3], ['c', 7, 0.7]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])

--- a/dice_ml/utils/helpers.py
+++ b/dice_ml/utils/helpers.py
@@ -141,6 +141,15 @@ def load_custom_testing_dataset_binary():
     data = [['a', 1, 0], ['b', 5, 1], ['c', 2, 0], ['a', 3, 0], ['c', 4, 1]]
     return pd.DataFrame(data, columns=['Categorical', 'Numerical', 'Outcome'])
 
+def load_custom_testing_dataset_binary_str():
+    data = [
+        ["a", 1, "zero"],
+        ["b", 5, "one"],
+        ["c", 2, "zero"],
+        ["a", 3, "one"],
+        ["c", 4, "one"],
+    ]
+    return pd.DataFrame(data, columns=["Categorical", "Numerical", "Outcome"])
 
 def load_custom_testing_dataset_multiclass():
     data = [['a', 10, 1], ['b', 20, 2], ['c', 14, 1], ['a', 23, 2], ['c', 7, 0]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,29 @@ def random_binary_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='random')
     return exp
 
+@pytest.fixture(scope="session", params=product(["sklearn"], DATA_INTERFACES))
+def random_str_binary_classification_exp_object(request):
+    backend, dinterface = request.param
+    if dinterface == "public":
+        dataset = helpers.load_custom_testing_dataset_binary_str()
+        d = dice_ml.Data(
+            dataframe=dataset, continuous_features=["Numerical"], outcome_name="Outcome"
+        )
+    else:
+        d = dice_ml.Data(
+            features={"Numerical": [0, 5], "Categorical": ["a", "b", "c"]},
+            outcome_name="Outcome",
+        )
+    if backend == "PYT":
+        torch.manual_seed(1)
+        net = FFNetwork(4)
+        m = dice_ml.Model(model=net, backend=backend, func="ohe-min-max")
+    else:
+        model = _load_custom_testing_binary_str_model()
+        m = dice_ml.Model(model=model, backend=backend)
+    exp = dice_ml.Dice(d, m, method="random")
+    print(m.model.classes_)
+    return exp
 
 # TODO multiclass is not currently supported for neural networks
 @pytest.fixture(scope="module", params=product(['sklearn'], DATA_INTERFACES))
@@ -95,6 +118,21 @@ def genetic_binary_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='genetic')
     return exp
 
+@pytest.fixture(scope="module", params=["sklearn"])
+def genetic_binary_str_classification_exp_object(request):
+    backend = request.param
+    dataset = helpers.load_custom_testing_dataset_binary_str()
+    d = dice_ml.Data(
+        dataframe=dataset, continuous_features=["Numerical"], outcome_name="Outcome"
+    )
+    if backend == "PYT":
+        net = FFNetwork(4)
+        m = dice_ml.Model(model=net, backend=backend, func="ohe-min-max")
+    else:
+        model = _load_custom_testing_binary_str_model()
+        m = dice_ml.Model(model=model, backend=backend)
+    exp = dice_ml.Dice(d, m, method="genetic")
+    return exp
 
 @pytest.fixture(scope="module", params=['sklearn'])
 def genetic_multi_classification_exp_object(request):
@@ -288,6 +326,15 @@ def _load_custom_testing_binary_model():
         X_train, y_train, num_feature_names, cat_feature_names)
     return model
 
+def _load_custom_testing_binary_str_model():
+    dataset = helpers.load_custom_testing_dataset_binary_str()
+    X_train = dataset[["Categorical", "Numerical"]]
+    y_train = dataset["Outcome"].values
+    num_feature_names = ["Numerical"]
+    cat_feature_names = ["Categorical"]
+    model = create_complex_classification_pipeline(
+        X_train, y_train, num_feature_names, cat_feature_names)
+    return model
 
 def _load_custom_testing_multiclass_model():
     dataset = helpers.load_custom_testing_dataset_multiclass()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,6 @@ def random_str_binary_classification_exp_object(request):
         model = _load_custom_testing_binary_str_model()
         m = dice_ml.Model(model=model, backend=backend)
     exp = dice_ml.Dice(d, m, method="random")
-    print(m.model.classes_)
     return exp
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,27 @@ def random_multi_classification_exp_object(request):
     return exp
 
 
+@pytest.fixture(scope="module", params=product(['sklearn'], DATA_INTERFACES))
+def random_str_multi_classification_exp_object(request):
+    backend, dinterface = request.param
+    if dinterface == "public":
+        dataset = helpers.load_custom_testing_dataset_multiclass_str()
+        d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
+    else:
+        d = dice_ml.Data(features={
+                                   'Numerical': [7, 23],
+                                   'Categorical': ['a', 'b', 'c']},
+                         outcome_name="Outcome")
+    if backend == "PYT":
+        net = FFNetwork(4)
+        m = dice_ml.Model(model=net, backend=backend,  func="ohe-min-max")
+    else:
+        model = _load_custom_testing_multiclass_str_model()
+        m = dice_ml.Model(model=model, backend=backend)
+    exp = dice_ml.Dice(d, m, method='random')
+    return exp
+
+
 @pytest.fixture(scope="module", params=product(BACKENDS, DATA_INTERFACES))
 def random_regression_exp_object(request):
     backend, dinterface = request.param
@@ -147,6 +168,15 @@ def genetic_multi_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='genetic')
     return exp
 
+@pytest.fixture(scope="module", params=['sklearn'])
+def genetic_str_multi_classification_exp_object(request):
+    backend = request.param
+    dataset = helpers.load_custom_testing_dataset_multiclass_str()
+    d = dice_ml.Data(dataframe=dataset, continuous_features=['Numerical'], outcome_name='Outcome')
+    model = _load_custom_testing_multiclass_str_model()
+    m = dice_ml.Model(model=model, backend=backend)
+    exp = dice_ml.Dice(d, m, method='genetic')
+    return exp
 
 @pytest.fixture(scope="module", params=BACKENDS)
 def genetic_regression_exp_object(request):
@@ -343,6 +373,17 @@ def _load_custom_testing_binary_str_model():
 
 def _load_custom_testing_multiclass_model():
     dataset = helpers.load_custom_testing_dataset_multiclass()
+    X_train = dataset[["Categorical", "Numerical"]]
+    y_train = dataset["Outcome"].values
+    num_feature_names = ["Numerical"]
+    cat_feature_names = ["Categorical"]
+    model = create_complex_classification_pipeline(
+        X_train, y_train, num_feature_names, cat_feature_names)
+    return model
+
+
+def _load_custom_testing_multiclass_str_model():
+    dataset = helpers.load_custom_testing_dataset_multiclass_str()
     X_train = dataset[["Categorical", "Numerical"]]
     y_train = dataset["Outcome"].values
     num_feature_names = ["Numerical"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ def genetic_multi_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='genetic')
     return exp
 
+
 @pytest.fixture(scope="module", params=['sklearn'])
 def genetic_str_multi_classification_exp_object(request):
     backend = request.param
@@ -177,6 +178,7 @@ def genetic_str_multi_classification_exp_object(request):
     m = dice_ml.Model(model=model, backend=backend)
     exp = dice_ml.Dice(d, m, method='genetic')
     return exp
+
 
 @pytest.fixture(scope="module", params=BACKENDS)
 def genetic_regression_exp_object(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,7 +349,7 @@ def _load_custom_testing_regression_model():
 
 
 def load_custom_vars_testing_dataset():
-    data = [['a', 0, 10, 0], ['b', 1, 10000, 0], ['c', 0, 14, 0], ['a', 2, 88, 0], ['c', 1, 14, 0]]
+    data = [['a', 0, 10, 0], ['b', 1, 10000, 1], ['c', 0, 14, 0], ['a', 2, 88, 0], ['c', 1, 14, 0]]
     return pd.DataFrame(data, columns=['Categorical', 'CategoricalNum', 'Numerical', 'Outcome'])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def random_binary_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='random')
     return exp
 
+
 @pytest.fixture(scope="session", params=product(["sklearn"], DATA_INTERFACES))
 def random_str_binary_classification_exp_object(request):
     backend, dinterface = request.param
@@ -60,6 +61,7 @@ def random_str_binary_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method="random")
     print(m.model.classes_)
     return exp
+
 
 # TODO multiclass is not currently supported for neural networks
 @pytest.fixture(scope="module", params=product(['sklearn'], DATA_INTERFACES))
@@ -118,6 +120,7 @@ def genetic_binary_classification_exp_object(request):
     exp = dice_ml.Dice(d, m, method='genetic')
     return exp
 
+
 @pytest.fixture(scope="module", params=["sklearn"])
 def genetic_binary_str_classification_exp_object(request):
     backend = request.param
@@ -133,6 +136,7 @@ def genetic_binary_str_classification_exp_object(request):
         m = dice_ml.Model(model=model, backend=backend)
     exp = dice_ml.Dice(d, m, method="genetic")
     return exp
+
 
 @pytest.fixture(scope="module", params=['sklearn'])
 def genetic_multi_classification_exp_object(request):
@@ -326,6 +330,7 @@ def _load_custom_testing_binary_model():
         X_train, y_train, num_feature_names, cat_feature_names)
     return model
 
+
 def _load_custom_testing_binary_str_model():
     dataset = helpers.load_custom_testing_dataset_binary_str()
     X_train = dataset[["Categorical", "Numerical"]]
@@ -335,6 +340,7 @@ def _load_custom_testing_binary_str_model():
     model = create_complex_classification_pipeline(
         X_train, y_train, num_feature_names, cat_feature_names)
     return model
+
 
 def _load_custom_testing_multiclass_model():
     dataset = helpers.load_custom_testing_dataset_multiclass()

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -81,8 +81,9 @@ class TestDiceKDBinaryClassificationMethods:
 
         expected_output = self.exp.data_interface.data_df.iloc[np.r_[2, 0]][self.exp.data_interface.feature_names]
         expected_output = expected_output.reset_index(drop=True)
-
-        assert all(self.exp.final_cfs_df == expected_output)
+        print(expected_output)
+        print(self.exp.final_cfs_df)
+        assert all(self.exp.final_cfs_df.drop(columns="Outcome") == expected_output)
 
     # Testing for index returned
     @pytest.mark.parametrize(("desired_class", "total_CFs"), [(0, 1)])

--- a/tests/test_dice_interface/test_dice_KD.py
+++ b/tests/test_dice_interface/test_dice_KD.py
@@ -81,8 +81,6 @@ class TestDiceKDBinaryClassificationMethods:
 
         expected_output = self.exp.data_interface.data_df.iloc[np.r_[2, 0]][self.exp.data_interface.feature_names]
         expected_output = expected_output.reset_index(drop=True)
-        print(expected_output)
-        print(self.exp.final_cfs_df)
         assert all(self.exp.final_cfs_df.drop(columns="Outcome") == expected_output)
 
     # Testing for index returned

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -120,7 +120,9 @@ class TestDiceGeneticBinaryStrClassificationMethods:
     # When invalid desired_class is given
     @pytest.mark.parametrize(("desired_class", "total_CFs"), [(7, 3)])
     def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
-        with pytest.raises(UserConfigValidationException):
+        with pytest.raises(
+                UserConfigValidationException,
+                match="Desired class not present in training data"):
             self.exp.generate_counterfactuals(
                 query_instances=sample_custom_query_1,
                 total_CFs=total_CFs,

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -198,6 +198,7 @@ class TestDiceGeneticMultiClassificationMethods:
         assert hasattr(preds, "shape"), "The object that contains the predictions doesn't have a 'shape' attribute."
         assert preds.shape[0] == df.shape[0], "The number of predictions differs from the number of elements in the dataset."
 
+
 class TestDiceGeneticStrMultiClassificationMethods:
     @pytest.fixture(autouse=True)
     def _initiate_exp_object(self, genetic_str_multi_classification_exp_object):

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -136,7 +136,11 @@ class TestDiceGeneticBinaryStrClassificationMethods:
             total_CFs=total_CFs,
             desired_class=desired_class,
         )
-        print(ans.cf_examples_list[0].final_cfs_df)
+        assert all(
+            ans.cf_examples_list[0]
+            .final_cfs_df["Outcome"]
+            .isin(["one", "zero"])
+        )
 
 
 class TestDiceGeneticMultiClassificationMethods:

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -112,6 +112,33 @@ class TestDiceGeneticBinaryClassificationMethods:
         assert custom_preds[0] == desired_class
 
 
+class TestDiceGeneticBinaryStrClassificationMethods:
+    @pytest.fixture(autouse=True)
+    def _initiate_exp_object(self, genetic_binary_str_classification_exp_object):
+        self.exp = genetic_binary_str_classification_exp_object  # explainer object
+
+    # When invalid desired_class is given
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(7, 3)])
+    def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
+        with pytest.raises(UserConfigValidationException):
+            self.exp.generate_counterfactuals(
+                query_instances=sample_custom_query_1,
+                total_CFs=total_CFs,
+                desired_class=desired_class,
+            )
+
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(0, 3)])
+    def test_outcome_in_original_labels(
+        self, desired_class, sample_custom_query_1, total_CFs
+    ):
+        ans = self.exp.generate_counterfactuals(
+            query_instances=sample_custom_query_1,
+            total_CFs=total_CFs,
+            desired_class=desired_class,
+        )
+        print(ans.cf_examples_list[0].final_cfs_df)
+
+
 class TestDiceGeneticMultiClassificationMethods:
     @pytest.fixture(autouse=True)
     def _initiate_exp_object(self, genetic_multi_classification_exp_object):

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -198,6 +198,38 @@ class TestDiceGeneticMultiClassificationMethods:
         assert hasattr(preds, "shape"), "The object that contains the predictions doesn't have a 'shape' attribute."
         assert preds.shape[0] == df.shape[0], "The number of predictions differs from the number of elements in the dataset."
 
+class TestDiceGeneticStrMultiClassificationMethods:
+    @pytest.fixture(autouse=True)
+    def _initiate_exp_object(self, genetic_str_multi_classification_exp_object):
+        self.exp = genetic_str_multi_classification_exp_object  # explainer object
+
+    # When invalid desired_class is given
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(7, 3)])
+    def test_no_cfs(self, desired_class, sample_custom_query_1, total_CFs):
+        with pytest.raises(
+                UserConfigValidationException,
+                match="Desired class not present in training data"):
+            self.exp.generate_counterfactuals(
+                query_instances=sample_custom_query_1,
+                total_CFs=total_CFs,
+                desired_class=desired_class,
+            )
+
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(0, 3)])
+    def test_outcome_in_original_labels(
+        self, desired_class, sample_custom_query_1, total_CFs
+    ):
+        ans = self.exp.generate_counterfactuals(
+            query_instances=sample_custom_query_1,
+            total_CFs=total_CFs,
+            desired_class=desired_class,
+        )
+        assert all(
+            ans.cf_examples_list[0]
+            .final_cfs_df["Outcome"]
+            .isin(["one", "zero", "two"])
+        )
+
 
 class TestDiceGeneticRegressionMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -77,6 +77,36 @@ class TestDiceRandomBinaryClassificationMethods:
                 permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
                 in range(total_CFs))
 
+class TestDiceRandomStrBinaryClassificationMethods:
+    @pytest.fixture(autouse=True)
+    def _initiate_exp_object(self, random_str_binary_classification_exp_object):
+        self.exp = random_str_binary_classification_exp_object  # explainer object
+
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(0, 1)])
+    def test_random_counterfactual_explanations_output(
+        self, desired_class, sample_custom_query_1, total_CFs
+    ):
+        counterfactual_explanations = self.exp.generate_counterfactuals(
+            query_instances=sample_custom_query_1,
+            desired_class=desired_class,
+            total_CFs=total_CFs,
+        )
+
+        assert counterfactual_explanations is not None
+        assert (
+            len(counterfactual_explanations.cf_examples_list)
+            == sample_custom_query_1.shape[0]
+        )
+        assert (
+            counterfactual_explanations.cf_examples_list[0].final_cfs_df.shape[0]
+            == total_CFs
+        )
+        assert all(
+            counterfactual_explanations.cf_examples_list[0]
+            .final_cfs_df["Outcome"]
+            .isin(["one", "zero"])
+        )
+
 
 class TestDiceRandomRegressionMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -108,6 +108,36 @@ class TestDiceRandomStrBinaryClassificationMethods:
             .isin(["one", "zero"])
         )
 
+class TestDiceRandomStrMultiClassificationMethods:
+    @pytest.fixture(autouse=True)
+    def _initiate_exp_object(self, random_str_multi_classification_exp_object):
+        self.exp = random_str_multi_classification_exp_object  # explainer object
+
+    @pytest.mark.parametrize(("desired_class", "total_CFs"), [(0, 1)])
+    def test_random_counterfactual_explanations_output(
+        self, desired_class, sample_custom_query_1, total_CFs
+    ):
+        counterfactual_explanations = self.exp.generate_counterfactuals(
+            query_instances=sample_custom_query_1,
+            desired_class=desired_class,
+            total_CFs=total_CFs,
+        )
+
+        assert counterfactual_explanations is not None
+        assert (
+            len(counterfactual_explanations.cf_examples_list)
+            == sample_custom_query_1.shape[0]
+        )
+        assert (
+            counterfactual_explanations.cf_examples_list[0].final_cfs_df.shape[0]
+            == total_CFs
+        )
+        assert all(
+            counterfactual_explanations.cf_examples_list[0]
+            .final_cfs_df["Outcome"]
+            .isin(["one", "zero", "two"])
+        )
+
 
 class TestDiceRandomRegressionMethods:
     @pytest.fixture(autouse=True)

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -77,6 +77,7 @@ class TestDiceRandomBinaryClassificationMethods:
                 permitted_range[feature][0] <= ans.final_cfs_df[feature].values[i] <= permitted_range[feature][1] for i
                 in range(total_CFs))
 
+
 class TestDiceRandomStrBinaryClassificationMethods:
     @pytest.fixture(autouse=True)
     def _initiate_exp_object(self, random_str_binary_classification_exp_object):

--- a/tests/test_dice_interface/test_dice_random.py
+++ b/tests/test_dice_interface/test_dice_random.py
@@ -108,6 +108,7 @@ class TestDiceRandomStrBinaryClassificationMethods:
             .isin(["one", "zero"])
         )
 
+
 class TestDiceRandomStrMultiClassificationMethods:
     @pytest.fixture(autouse=True)
     def _initiate_exp_object(self, random_str_multi_classification_exp_object):


### PR DESCRIPTION
Fixes #369.

Only supported for sklearn models since pytorch/tf models cannot accept non-numeric labels. 