### PR TITLE
Change from pandas append method to pd.concat

### DIFF
--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -379,7 +379,7 @@ class PrivateData(_BaseData):
            a dataframe, a list, or a list of dicts"""
         query_instance = self.prepare_query_instance(query_instance)
         ohe_base_df = self.prepare_df_for_ohe_encoding()
-        temp = ohe_base_df.append(query_instance, ignore_index=True, sort=False)
+        temp = pd.concat([ohe_base_df, query_instance], ignore_index=True, sort=False)
         temp = self.one_hot_encode_data(temp)
         temp = temp.tail(query_instance.shape[0]).reset_index(drop=True)
         # returns a pandas dataframe


### PR DESCRIPTION
Looks like the `append` method will be deprecated soon based on the message below:-

```
  C:\Users\gaugup\Documents\Github\DiCE\dice_ml\data_interfaces\private_data_interface.py:382: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
    temp = ohe_base_df.append(query_instance, ignore_index=True, sort=False)
```