### PR TITLE
Implement Counterplots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas<2.0.0
 scikit-learn
 tqdm
 raiutils>=0.4.0
+counterplots>=0.0.7

--- a/tests/test_counterfactual_explanations.py
+++ b/tests/test_counterfactual_explanations.py
@@ -1,8 +1,12 @@
 import json
 
 import pytest
+import unittest
+from unittest.mock import patch, Mock
 from raiutils.exceptions import UserConfigValidationException
 
+import pandas as pd
+import numpy as np
 from dice_ml.counterfactual_explanations import CounterfactualExplanations
 
 
@@ -319,3 +323,78 @@ class TestSerializationCounterfactualExplanations:
             counterfactual_explanations.to_json()
 
         assert "Unsupported serialization version {}".format(unsupported_version) in str(ucve)
+
+
+class TestCounterfactualExplanations(unittest.TestCase):
+
+    @patch('dice_ml.counterfactual_explanations.CreatePlot', return_value="dummy_plot")
+    def test_plot_counterplots_sklearn(self, mock_create_plot):
+        # Dummy DiCE's model object with a Sklearn backend
+        dummy_model = Mock()
+        dummy_model.backend = "sklearn"
+        dummy_model.model.predict_proba = Mock(return_value=np.array([[0.4, 0.6], [0.2, 0.8]]))
+
+        # Sample cf_examples to test with
+        cf_examples_mock = Mock()
+        cf_examples_mock.test_instance_df = pd.DataFrame({
+            'feature1': [1],
+            'feature2': [2],
+            'target': [0]
+        })
+        cf_examples_mock.final_cfs_df = pd.DataFrame({
+            'feature1': [1.1, 1.2],
+            'feature2': [2.1, 2.2],
+            'target': [1, 1]
+        })
+
+        counterfact = CounterfactualExplanations(
+            cf_examples_list=[cf_examples_mock],
+            local_importance=None,
+            summary_importance=None,
+            version=None)
+
+        # Call function
+        result = counterfact.plot_counterplots(dummy_model)
+
+        # Assert the CreatePlot was called twice (as there are 2 counterfactual instances)
+        self.assertEqual(mock_create_plot.call_count, 2)
+
+        # Assert that the result is as expected
+        self.assertEqual(result, ["dummy_plot", "dummy_plot"])
+
+    @patch('dice_ml.counterfactual_explanations.CreatePlot', return_value="dummy_plot")
+    def test_plot_counterplots_non_sklearn(self, mock_create_plot):
+        # Sample Non-Sklearn backend
+        dummy_model = Mock()
+        dummy_model.backend = "NonSklearn"
+        dummy_model.model.predict = Mock(return_value=np.array([0, 1]))
+        dummy_model.transformer = Mock()
+        dummy_model.transformer.transform = Mock(return_value=np.array([[1, 2], [1.1, 2.1]]))
+
+        # Sample cf_examples to test with
+        cf_examples_mock = Mock()
+        cf_examples_mock.test_instance_df = pd.DataFrame({
+            'feature1': [1],
+            'feature2': [2],
+            'target': [0]
+        })
+        cf_examples_mock.final_cfs_df = pd.DataFrame({
+            'feature1': [1.1, 1.2],
+            'feature2': [2.1, 2.2],
+            'target': [1, 1]
+        })
+
+        counterfact = CounterfactualExplanations(
+            cf_examples_list=[cf_examples_mock],
+            local_importance=None,
+            summary_importance=None,
+            version=None)
+
+        # Call function
+        result = counterfact.plot_counterplots(dummy_model)
+
+        # Assert the CreatePlot was called twice (as there are 2 counterfactual instances)
+        self.assertEqual(mock_create_plot.call_count, 2)
+
+        # Assert that the result is as expected
+        self.assertEqual(result, ["dummy_plot", "dummy_plot"])


### PR DESCRIPTION
Code for counterplots using DiCE TF example:

Here is the repo for CounterPlots (https://github.com/ADMAntwerp/CounterPlots) and how they look like, I believe they will greatly improve the usability of counterfactual explanations with comprehensive visuals and charts.

```python
import dice_ml
from dice_ml.utils import helpers # helper functions
from sklearn.model_selection import train_test_split

dataset = helpers.load_adult_income_dataset()
target = dataset["income"] # outcome variable
train_dataset, test_dataset, _, _ = train_test_split(dataset,
                                                     target,
                                                     test_size=0.2,
                                                     random_state=0,
                                                     stratify=target)
# Dataset for training an ML model
d = dice_ml.Data(dataframe=train_dataset,
                 continuous_features=['age', 'hours_per_week'],
                 outcome_name='income')

# Pre-trained ML model
m = dice_ml.Model(model_path=dice_ml.utils.helpers.get_adult_income_modelpath(),
                  backend='TF2', func="ohe-min-max")
# DiCE explanation instance
exp = dice_ml.Dice(d,m)

# Generate counterfactual examples
query_instance = test_dataset.drop(columns="income")[0:1]
dice_exp = exp.generate_counterfactuals(query_instance, total_CFs=4, desired_class="opposite")
# Visualize counterfactual explanation
dice_exp.visualize_as_dataframe()

# Create counterplots
ctp = dice_exp.plot_counterplots(m)

# Counterplots outputs
ctp[0].constellation()
ctp[0].greedy()
ctp[0].countershapley()
ctp[0].countershapley_values()
```

Example using Scikit-Learn:

```python
import dice_ml
from dice_ml import Dice

from sklearn.datasets import load_iris, fetch_california_housing
from sklearn.pipeline import Pipeline
from sklearn.preprocessing import StandardScaler, OneHotEncoder
from sklearn.model_selection import train_test_split
from sklearn.compose import ColumnTransformer
from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

import pandas as pd

df_iris = load_iris(as_frame=True).frame
df_iris.head()

df_iris.info()

outcome_name = "target"
continuous_features_iris = df_iris.drop(outcome_name, axis=1).columns.tolist()
target = df_iris[outcome_name]

# Split data into train and test
datasetX = df_iris.drop(outcome_name, axis=1)
x_train, x_test, y_train, y_test = train_test_split(datasetX,
                                                    target,
                                                    test_size=0.2,
                                                    random_state=0,
                                                    stratify=target)

categorical_features = x_train.columns.difference(continuous_features_iris)

# We create the preprocessing pipelines for both numeric and categorical data.
numeric_transformer = Pipeline(steps=[
    ('scaler', StandardScaler())])

categorical_transformer = Pipeline(steps=[
    ('onehot', OneHotEncoder(handle_unknown='ignore'))])

transformations = ColumnTransformer(
    transformers=[
        ('num', numeric_transformer, continuous_features_iris),
        ('cat', categorical_transformer, categorical_features)])

# Append classifier to preprocessing pipeline.
# Now we have a full prediction pipeline.
clf_iris = Pipeline(steps=[('preprocessor', transformations),
                           ('classifier', RandomForestClassifier())])
model_iris = clf_iris.fit(x_train, y_train)

d_iris = dice_ml.Data(dataframe=df_iris,
                      continuous_features=continuous_features_iris,
                      outcome_name=outcome_name)

# We provide the type of model as a parameter (model_type)
m_iris = dice_ml.Model(model=model_iris, backend="sklearn", model_type='classifier')

exp_genetic_iris = Dice(d_iris, m_iris, method="genetic")

# Single input
query_instances_iris = x_test[2:3]
genetic_iris = exp_genetic_iris.generate_counterfactuals(query_instances_iris, total_CFs=7, desired_class=2)
genetic_iris.visualize_as_dataframe()

# Create counterplots
ctps = genetic_iris.plot_counterplots(m_iris)

# Counterplots output
ctps[0].greedy()
ctps[0].countershapley()
ctps[0].countershapley_values()
ctps[0].constellation()
```