### PR TITLE
Raise user error when any of the query instances has missing values

### DIFF
--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -1,3 +1,6 @@
+import re
+
+import numpy as np
 import pandas as pd
 import pytest
 from raiutils.exceptions import UserConfigValidationException
@@ -497,6 +500,27 @@ class TestExplainerBaseUserConfigValidations:
             method=method)
 
         explainer_function = getattr(exp, explainer_function)
+
+        regex_pattern = re.escape(
+            'The query instance(s) should not have any missing values. '
+            'Please impute the missing values and try again.')
+
+        query_instances_missing_values_numerical = pd.DataFrame({'Categorical': ['a'], 'Numerical': [np.nan]})
+        with pytest.raises(
+                UserConfigValidationException,
+                match=regex_pattern):
+            explainer_function(
+                query_instances=query_instances_missing_values_numerical, desired_class='opposite',
+                total_CFs=10)
+
+        query_instances_missing_values_categorical = pd.DataFrame({'Categorical': [np.nan], 'Numerical': [1]})
+        with pytest.raises(
+                UserConfigValidationException,
+                match=regex_pattern):
+            explainer_function(
+                query_instances=query_instances_missing_values_categorical, desired_class='opposite',
+                total_CFs=10)
+
         with pytest.raises(
                 UserConfigValidationException,
                 match=r"The number of counterfactuals generated per query instance \(total_CFs\) "


### PR DESCRIPTION
Looks like missing values in query instances cause weird failures when attempting to do predict()/predict_proba(). Hence, asking the user to impute the values for missing values.