### PR TITLE
Ensure same type for CF output as the input features

### DIFF
--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -2,11 +2,10 @@
 
 from abc import ABC, abstractmethod
 
+import pandas as pd
 from raiutils.exceptions import UserConfigValidationException
 
 from dice_ml.utils.exception import SystemException
-
-import pandas as pd
 
 
 class _BaseData(ABC):

--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -6,6 +6,8 @@ from raiutils.exceptions import UserConfigValidationException
 
 from dice_ml.utils.exception import SystemException
 
+import pandas as pd
+
 
 class _BaseData(ABC):
 

--- a/dice_ml/data_interfaces/base_data_interface.py
+++ b/dice_ml/data_interfaces/base_data_interface.py
@@ -71,6 +71,31 @@ class _BaseData(ABC):
                     )
         self.permitted_range, _ = self.get_features_range(input_permitted_range, features_dict)
 
+    def ensure_consistent_type(self, output_df, query_instance):
+        qdf = self.query_instance_to_df(query_instance)
+        output_df = output_df.astype(qdf.dtypes.to_dict())
+        return output_df
+
+    def query_instance_to_df(self, query_instance):
+        if isinstance(query_instance, list):
+            if isinstance(query_instance[0], dict):  # prepare a list of query instances
+                test = pd.DataFrame(query_instance, columns=self.feature_names)
+
+            else:  # prepare a single query instance in list
+                query_instance = {'row1': query_instance}
+                test = pd.DataFrame.from_dict(
+                    query_instance, orient='index', columns=self.feature_names)
+
+        elif isinstance(query_instance, dict):
+            test = pd.DataFrame({k: [v] for k, v in query_instance.items()}, columns=self.feature_names)
+
+        elif isinstance(query_instance, pd.DataFrame):
+            test = query_instance.copy()
+
+        else:
+            raise ValueError("Query instance should be a dict, a pandas dataframe, a list, or a list of dicts")
+        return test
+
     @abstractmethod
     def __init__(self, params):
         """The init method needs to be implemented by the inherting classes."""

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -351,11 +351,6 @@ class PrivateData(_BaseData):
 
         return df
 
-    def ensure_consistent_type(self, output_df, query_instance):
-        qdf = self.query_instance_to_df(query_instance)
-        output_df = output_df.astype(qdf.dtypes.to_dict())
-        return output_df
-
     def query_instance_to_df(self, query_instance):
         if isinstance(query_instance, list):
             if isinstance(query_instance[0], dict):  # prepare a list of query instances

--- a/dice_ml/data_interfaces/private_data_interface.py
+++ b/dice_ml/data_interfaces/private_data_interface.py
@@ -351,8 +351,12 @@ class PrivateData(_BaseData):
 
         return df
 
-    def prepare_query_instance(self, query_instance):
-        """Prepares user defined test input(s) for DiCE."""
+    def ensure_consistent_type(self, output_df, query_instance):
+        qdf = self.query_instance_to_df(query_instance)
+        output_df = output_df.astype(qdf.dtypes.to_dict())
+        return output_df
+
+    def query_instance_to_df(self, query_instance):
         if isinstance(query_instance, list):
             if isinstance(query_instance[0], dict):  # prepare a list of query instances
                 test = pd.DataFrame(query_instance, columns=self.feature_names)
@@ -370,7 +374,11 @@ class PrivateData(_BaseData):
 
         else:
             raise ValueError("Query instance should be a dict, a pandas dataframe, a list, or a list of dicts")
+        return test
 
+    def prepare_query_instance(self, query_instance):
+        """Prepares user defined test input(s) for DiCE."""
+        test = self.query_instance_to_df(query_instance)
         test = test.reset_index(drop=True)
         return test
 

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -449,25 +449,6 @@ class PublicData(_BaseData):
 
         return df
 
-    def query_instance_to_df(self, query_instance):
-        if isinstance(query_instance, list):
-            if isinstance(query_instance[0], dict):  # prepare a list of query instances
-                test = pd.DataFrame(query_instance, columns=self.feature_names)
-
-            else:  # prepare a single query instance in list
-                query_instance = {'row1': query_instance}
-                test = pd.DataFrame.from_dict(
-                    query_instance, orient='index', columns=self.feature_names)
-
-        elif isinstance(query_instance, dict):
-            test = pd.DataFrame({k: [v] for k, v in query_instance.items()}, columns=self.feature_names)
-
-        elif isinstance(query_instance, pd.DataFrame):
-            test = query_instance.copy()
-        else:
-            raise ValueError("Query instance should be a dict, a pandas dataframe, a list, or a list of dicts")
-        return test
-
     def prepare_query_instance(self, query_instance):
         """Prepares user defined test input(s) for DiCE."""
         test = self.query_instance_to_df(query_instance)
@@ -477,11 +458,6 @@ class PublicData(_BaseData):
                                         self.categorical_feature_names,
                                         self.continuous_feature_names)
         return test
-
-    def ensure_consistent_type(self, output_df, query_instance):
-        qdf = self.query_instance_to_df(query_instance)
-        output_df = output_df.astype(qdf.dtypes.to_dict())
-        return output_df
 
     def get_ohe_min_max_normalized_data(self, query_instance):
         """Transforms query_instance into one-hot-encoded and min-max normalized data. query_instance should be a dict,

--- a/dice_ml/data_interfaces/public_data_interface.py
+++ b/dice_ml/data_interfaces/public_data_interface.py
@@ -449,8 +449,7 @@ class PublicData(_BaseData):
 
         return df
 
-    def prepare_query_instance(self, query_instance):
-        """Prepares user defined test input(s) for DiCE."""
+    def query_instance_to_df(self, query_instance):
         if isinstance(query_instance, list):
             if isinstance(query_instance[0], dict):  # prepare a list of query instances
                 test = pd.DataFrame(query_instance, columns=self.feature_names)
@@ -465,16 +464,24 @@ class PublicData(_BaseData):
 
         elif isinstance(query_instance, pd.DataFrame):
             test = query_instance.copy()
-
         else:
             raise ValueError("Query instance should be a dict, a pandas dataframe, a list, or a list of dicts")
+        return test
 
+    def prepare_query_instance(self, query_instance):
+        """Prepares user defined test input(s) for DiCE."""
+        test = self.query_instance_to_df(query_instance)
         test = test.reset_index(drop=True)
         # encode categorical and numerical columns
         test = self._set_feature_dtypes(test,
                                         self.categorical_feature_names,
                                         self.continuous_feature_names)
         return test
+
+    def ensure_consistent_type(self, output_df, query_instance):
+        qdf = self.query_instance_to_df(query_instance)
+        output_df = output_df.astype(qdf.dtypes.to_dict())
+        return output_df
 
     def get_ohe_min_max_normalized_data(self, query_instance):
         """Transforms query_instance into one-hot-encoded and min-max normalized data. query_instance should be a dict,

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -194,6 +194,12 @@ class ExplainerBase(ABC):
                 posthoc_sparsity_algorithm=posthoc_sparsity_algorithm,
                 verbose=verbose,
                 **kwargs)
+            res.test_instance_df = self.data_interface.ensure_consistent_type(
+                    res.test_instance_df, query_instance)
+            res.final_cfs_df = self.data_interface.ensure_consistent_type(
+                    res.final_cfs_df, query_instance)
+            res.final_cfs_df_sparse = self.data_interface.ensure_consistent_type(
+                    res.final_cfs_df_sparse, query_instance)
             cf_examples_arr.append(res)
         self._check_any_counterfactuals_computed(cf_examples_arr=cf_examples_arr)
 

--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -196,9 +196,11 @@ class ExplainerBase(ABC):
                 **kwargs)
             res.test_instance_df = self.data_interface.ensure_consistent_type(
                     res.test_instance_df, query_instance)
-            res.final_cfs_df = self.data_interface.ensure_consistent_type(
+            if res.final_cfs_df is not None and len(res.final_cfs_df) > 0:
+                res.final_cfs_df = self.data_interface.ensure_consistent_type(
                     res.final_cfs_df, query_instance)
-            res.final_cfs_df_sparse = self.data_interface.ensure_consistent_type(
+            if res.final_cfs_df_sparse is not None and len(res.final_cfs_df_sparse) > 0:
+                res.final_cfs_df_sparse = self.data_interface.ensure_consistent_type(
                     res.final_cfs_df_sparse, query_instance)
             cf_examples_arr.append(res)
         self._check_any_counterfactuals_computed(cf_examples_arr=cf_examples_arr)

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -334,8 +334,10 @@ class TestExplainerBaseBinaryClassification:
                     desired_class=desired_class)
         for col in sample_custom_query.columns:
             assert cf_explanations.cf_examples_list[0].test_instance_df[col].dtype == sample_custom_query[col].dtype
-            assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query[col].dtype
-            assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query[col].dtype
+            if cf_explanations.cf_examples_list[0].final_cfs_df is not None:
+                assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query[col].dtype
+            if cf_explanations.cf_examples_list[0].final_cfs_df_sparse is not None:
+                assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query[col].dtype
 
 
 @pytest.mark.parametrize("method", ['random', 'genetic', 'kdtree'])
@@ -464,8 +466,10 @@ class TestExplainerBaseMultiClassClassification:
 
         for col in sample_custom_query_1.columns:
             assert cf_explanations.cf_examples_list[0].test_instance_df[col].dtype == sample_custom_query_1[col].dtype
-            assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query_1[col].dtype
-            assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query_1[col].dtype
+            if cf_explanations.cf_examples_list[0].final_cfs_df is not None:
+                assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query_1[col].dtype
+            if cf_explanations.cf_examples_list[0].final_cfs_df_sparse is not None:
+                assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query_1[col].dtype
 
 
 class TestExplainerBaseRegression:

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -300,6 +300,7 @@ class TestExplainerBaseBinaryClassification:
                     permitted_range[feature][0] <= ans.cf_examples_list[0].final_cfs_df_sparse[feature].values[i] <=
                     permitted_range[feature][1] for i in range(total_CFs))
 
+
     # Testing for 0 CFs needed
     @pytest.mark.parametrize(("features_to_vary", "desired_class", "desired_range", "total_CFs", "permitted_range"),
                              [("all", 0, None, 0, None)])

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -317,6 +317,26 @@ class TestExplainerBaseBinaryClassification:
                                       total_CFs=total_CFs, desired_class=desired_class,
                                       desired_range=desired_range, permitted_range=permitted_range)
 
+    @pytest.mark.parametrize("desired_class", [1])
+    def test_cfs_type_consistency(
+            self, desired_class, method,
+            sample_custom_query_1, sample_counterfactual_example_dummy,
+            custom_public_data_interface,
+            sklearn_binary_classification_model_interface):
+        exp = dice_ml.Dice(
+            custom_public_data_interface,
+            sklearn_binary_classification_model_interface,
+            method=method)
+        sample_custom_query = pd.concat([sample_custom_query_1, sample_custom_query_1])
+        cf_explanations = exp.generate_counterfactuals(
+                    query_instances=sample_custom_query,
+                    total_CFs=2,
+                    desired_class=desired_class)
+        for col in sample_custom_query.columns:
+            assert cf_explanations.cf_examples_list[0].test_instance_df[col].dtype == sample_custom_query[col].dtype
+            assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query[col].dtype
+            assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query[col].dtype
+
 
 @pytest.mark.parametrize("method", ['random', 'genetic', 'kdtree'])
 class TestExplainerBaseMultiClassClassification:
@@ -428,6 +448,24 @@ class TestExplainerBaseMultiClassClassification:
                                       total_CFs=total_CFs, desired_class=desired_class,
                                       desired_range=desired_range, permitted_range=permitted_range)
 
+    @pytest.mark.parametrize("desired_class", [1])
+    def test_cfs_type_consistency(
+            self, desired_class, method, sample_custom_query_1,
+            custom_public_data_interface,
+            sklearn_multiclass_classification_model_interface):
+        exp = dice_ml.Dice(
+            custom_public_data_interface,
+            sklearn_multiclass_classification_model_interface,
+            method=method)
+        cf_explanations = exp.generate_counterfactuals(
+                    query_instances=[sample_custom_query_1],
+                    total_CFs=2,
+                    desired_class=desired_class)
+
+        for col in sample_custom_query_1.columns:
+            assert cf_explanations.cf_examples_list[0].test_instance_df[col].dtype == sample_custom_query_1[col].dtype
+            assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query_1[col].dtype
+            assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query_1[col].dtype
 
 class TestExplainerBaseRegression:
 

--- a/tests/test_dice_interface/test_explainer_base.py
+++ b/tests/test_dice_interface/test_explainer_base.py
@@ -300,7 +300,6 @@ class TestExplainerBaseBinaryClassification:
                     permitted_range[feature][0] <= ans.cf_examples_list[0].final_cfs_df_sparse[feature].values[i] <=
                     permitted_range[feature][1] for i in range(total_CFs))
 
-
     # Testing for 0 CFs needed
     @pytest.mark.parametrize(("features_to_vary", "desired_class", "desired_range", "total_CFs", "permitted_range"),
                              [("all", 0, None, 0, None)])
@@ -467,6 +466,7 @@ class TestExplainerBaseMultiClassClassification:
             assert cf_explanations.cf_examples_list[0].test_instance_df[col].dtype == sample_custom_query_1[col].dtype
             assert cf_explanations.cf_examples_list[0].final_cfs_df[col].dtype == sample_custom_query_1[col].dtype
             assert cf_explanations.cf_examples_list[0].final_cfs_df_sparse[col].dtype == sample_custom_query_1[col].dtype
+
 
 class TestExplainerBaseRegression:
 


### PR DESCRIPTION
Explainer methods perform different operations that may result in a different type for the output features in a CF (some of these are required). 

To ensure consistency, this PR adds a type consistency operation before returning the CFs.