### PR TITLE
Bug fix

### DIFF
--- a/dice_ml/explainer_interfaces/explainer_base.py
+++ b/dice_ml/explainer_interfaces/explainer_base.py
@@ -123,8 +123,6 @@ class ExplainerBase(ABC):
                                  desired_class="opposite", desired_range=None,
                                  permitted_range=None, features_to_vary="all",
                                  stopping_threshold=0.5, posthoc_sparsity_param=0.1,
-                                 proximity_weight=0.2, sparsity_weight=0.2, diversity_weight=5.0,
-                                 categorical_penalty=0.1,
                                  posthoc_sparsity_algorithm="linear", verbose=False, **kwargs):
         """General method for generating counterfactuals.
 


### PR DESCRIPTION
In ExplainerBase.generate_counterfactuals arguments proximity_weight, sparsity_weight, diversity_weight, and categorical_penalty aren't actually used, nor passed to corresponding inherited classes.
With this fix, they can be actually passed with as kwargs.

Additionally, the method "genetic" does not work when all data is categorical, due to the proximity_loss.
This should be solvable with proximity_weight=0.0, but due to the fact that we cannot pass proximity_weight, we get the following bug:
https://colab.research.google.com/drive/1Pdd_IHo_e-ywdvQcQ_zE6jnQ2MkYcl2h#scrollTo=58x7nHNgUwkk