### PR TITLE
Fix invalid JSON in DiCE_getting_started_feasible notebook (#439)

### DIFF
--- a/docs/source/notebooks/DiCE_getting_started_feasible.ipynb
+++ b/docs/source/notebooks/DiCE_getting_started_feasible.ipynb
@@ -361,5 +361,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
+ "nbformat_minor": 4
 }

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,6 +2,7 @@
 Adapted from the same code for the Microsoft DoWhy library.
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -103,3 +104,25 @@ def test_notebook(notebook_filename):
     _check_notebook_cell_outputs(NOTEBOOKS_PATH + notebook_filename)
     errors = _notebook_run(NOTEBOOKS_PATH + notebook_filename)
     assert len(errors) == 0
+
+
+def _all_notebook_paths():
+    return sorted(
+        os.path.join(NOTEBOOKS_PATH, f.name)
+        for f in os.scandir(NOTEBOOKS_PATH)
+        if f.name.endswith(".ipynb")
+    )
+
+
+@pytest.mark.parametrize("notebook_path", _all_notebook_paths())
+def test_notebook_is_valid_json(notebook_path):
+    """Every shipped notebook must be parseable as JSON.
+
+    Regression test for issue #439: the trailing comma after
+    ``"nbformat_minor": 4`` in DiCE_getting_started_feasible.ipynb
+    made the file unrenderable on GitHub and unopenable in JupyterLab.
+    Skipping execution (covered above) means a malformed notebook can
+    sit in the repo unnoticed; this cheap json.load gate catches it.
+    """
+    with open(notebook_path, "r", encoding="utf-8") as fh:
+        json.load(fh)


### PR DESCRIPTION
## Summary

`docs/source/notebooks/DiCE_getting_started_feasible.ipynb` shipped with a
trailing comma after `\"nbformat_minor\": 4` (last lines of the file), which
made the file invalid JSON. As @rmnldwg reported in #439, this prevents the
notebook from rendering on GitHub and from opening in JupyterLab
(`NotJSONError`). #425 reports the same symptom.

The notebook is currently `pytest.mark.skip`-ed in `tests/test_notebooks.py`
("needs changes after latest refactor"), so the malformed JSON has been able
to sit in the repo for >2 years without CI catching it.

## Why

Two changes here, the second is the load-bearing one:

1. **Fix**: drop the trailing comma so the notebook parses as JSON again.
2. **Regression guard**: add a tiny `test_notebook_is_valid_json` test that
   `json.load`s every `.ipynb` under `docs/source/notebooks/`. Cheap, no
   nbconvert/jupyter execution required, runs in the default test job. This
   means a notebook with malformed JSON can no longer be merged silently
   even if its nbconvert test stays skipped.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# Run from a fresh clone of interpretml/DiCE
set -e
cd /tmp && rm -rf DiCE-repro && git clone https://github.com/interpretml/DiCE.git DiCE-repro
cd DiCE-repro

# --- BEFORE: origin/main ---
git checkout origin/main -- docs/source/notebooks/DiCE_getting_started_feasible.ipynb
python -c "import json; json.load(open('docs/source/notebooks/DiCE_getting_started_feasible.ipynb'))" || echo "BEFORE: JSONDecodeError (expected)"
# Expected: \"Illegal trailing comma before end of object: line 364 column 21\"

# --- AFTER: this PR's branch ---
git fetch https://github.com/jbbqqf/DiCE.git fix/439-notebook-json
git checkout FETCH_HEAD -- docs/source/notebooks/DiCE_getting_started_feasible.ipynb tests/test_notebooks.py
python -c "import json; json.load(open('docs/source/notebooks/DiCE_getting_started_feasible.ipynb')); print('AFTER: parses OK')"
# Expected: \"AFTER: parses OK\"

pip install -q -e . pytest nbformat
pytest tests/test_notebooks.py::test_notebook_is_valid_json -q
# Expected: 8 passed (one per notebook under docs/source/notebooks/)
```

## What I ran locally

- `pytest tests/test_notebooks.py::test_notebook_is_valid_json` → **8 passed**
- Confirmed `json.load` raises on `origin/main` and parses on this branch
- Notebook still renders identically — only the trailing comma is removed

## Edge cases

| case | behaviour |
|---|---|
| All other notebooks under `docs/source/notebooks/` | All parse; new test now guards them |
| Future PR that introduces a malformed notebook | Test fails in default CI even if nbconvert run is skipped |
| Notebooks excluded via `advanced_notebooks` skip list | Still validated by JSON test (no execution required) |

## AI disclosure

This change was prepared with the assistance of Claude (Anthropic).
The author reviewed every line and is responsible for the final result.