### PR TITLE
Fix broken VAE notebook link in README.rst (#308)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ See `model-agnostic notebook
 **Gradient-based methods**
 
 * An explicit loss-based method described in `Mothilal et al. (2020) <https://arxiv.org/abs/1905.07697>`_ (Default for deep learning models).
-* A Variational AutoEncoder (VAE)-based method described in `Mahajan et al. (2019) <https://arxiv.org/abs/1912.03277>`_ (see the BaseVAE `notebook <https://github.com/interpretml/DiCE/blob/master/docs/notebooks/DiCE_getting_started_feasible.ipynb>`_).
+* A Variational AutoEncoder (VAE)-based method described in `Mahajan et al. (2019) <https://arxiv.org/abs/1912.03277>`_ (see the BaseVAE `notebook <https://github.com/interpretml/DiCE/blob/master/docs/source/notebooks/DiCE_getting_started_feasible.ipynb>`_).
 
 The last two methods require a differentiable model, such as a neural network. If you are interested in a specific method, do raise an issue `here <https://github.com/interpretml/DiCE/issues>`_.
 

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,49 @@
+"""Lightweight regression test for README notebook links.
+
+Issue #308 reported that the BaseVAE notebook link in README.rst pointed
+at `docs/notebooks/...` instead of the actual `docs/source/notebooks/...`
+path. The link had been broken for years because nothing in CI checked
+that in-repo notebook references resolve to real files.
+
+This test scans README.rst for any `https://github.com/interpretml/DiCE/
+blob/<ref>/docs/...notebook.ipynb` URL and asserts each one resolves to
+a file under the working tree. It only validates *in-repo* links — it
+does not hit the network.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+README_PATH = os.path.join(REPO_ROOT, "README.rst")
+
+# Match `https://github.com/interpretml/DiCE/blob/<ref>/<path>.ipynb`.
+_NOTEBOOK_RE = re.compile(
+    r"https://github\.com/interpretml/DiCE/blob/[^/]+/(?P<path>[^>\s)]+\.ipynb)"
+)
+
+
+def _readme_notebook_paths():
+    with open(README_PATH, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    return list({m.group("path") for m in _NOTEBOOK_RE.finditer(text)})
+
+
+def test_readme_lists_at_least_one_notebook_link():
+    # Sanity: if this drops to 0 the regex got broken or README was rewritten.
+    assert _readme_notebook_paths(), "README must list at least one notebook"
+
+
+def test_readme_notebook_links_resolve():
+    """Every notebook URL in README.rst must point to a file in the repo."""
+    missing = [
+        path
+        for path in _readme_notebook_paths()
+        if not os.path.isfile(os.path.join(REPO_ROOT, path))
+    ]
+    assert not missing, (
+        "README.rst links to notebooks that do not exist in the repo: "
+        f"{missing}. See issue #308 — make sure the URL path matches the "
+        "actual on-disk path under docs/source/notebooks/."
+    )


### PR DESCRIPTION
## Summary

The BaseVAE notebook URL in README.rst points at
`docs/notebooks/DiCE_getting_started_feasible.ipynb`, but the actual on-disk
path is `docs/source/notebooks/DiCE_getting_started_feasible.ipynb`. As
@reilankoba reported in #308, the link has been 404 for users since the
`docs/source/` reorganisation.

## Why

Two changes:

1. **Fix**: correct the URL path in README.rst (insert the missing `source/`
   segment).
2. **Regression guard**: add `tests/test_readme_links.py` that scans every
   `https://github.com/interpretml/DiCE/blob/<ref>/<path>.ipynb` URL in
   README.rst and asserts each path resolves to a real file under the
   working tree. No network access — purely an in-repo path check. This
   stops future folder renames from silently 404-ing notebook links.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
set -e
cd /tmp && rm -rf DiCE-308 && git clone https://github.com/interpretml/DiCE.git DiCE-308
cd DiCE-308

# Apply the new test to both refs (it's a new file)
git fetch https://github.com/jbbqqf/DiCE.git fix/308-readme-vae-link
git checkout FETCH_HEAD -- tests/test_readme_links.py
pip install -q -e . pytest

# --- BEFORE: README.rst from origin/main ---
git checkout origin/main -- README.rst
python -m pytest tests/test_readme_links.py::test_readme_notebook_links_resolve -q || echo \"BEFORE: FAIL (expected)\"
# Expected: AssertionError listing 'docs/notebooks/DiCE_getting_started_feasible.ipynb'

# --- AFTER: README.rst from this PR ---
git checkout FETCH_HEAD -- README.rst
python -m pytest tests/test_readme_links.py -q
# Expected: 2 passed
```

## What I ran locally

- `pytest tests/test_readme_links.py` → **2 passed** on this branch
- Test fails on `origin/main` README with the expected missing-path message
- Verified all 7 in-repo notebook URLs in README.rst now resolve

## Edge cases

| case | behaviour |
|---|---|
| README link points to a file under `docs/source/notebooks/` | passes |
| README link points to a non-existent path | test fails with the missing path printed |
| External URL (e.g. arxiv.org, mybinder.org) | not matched — only GitHub blob URLs are checked |
| Notebook moved without README update | test fails — exactly the regression we want to catch |

## AI disclosure

This change was prepared with the assistance of Claude (Anthropic).
The author reviewed every line and is responsible for the final result.