### PR TITLE
Fix DiceGenetic.compute_proximity_loss for all-categorical datasets (#276)

### DIFF
--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -370,6 +370,14 @@ class DiceGenetic(ExplainerBase):
         x_hat = self.data_interface.normalize_data(x_hat_unnormalized)
         feature_weights = np.array(
             [self.feature_weights_list[0][i] for i in self.data_interface.continuous_feature_indexes])
+        # When the dataset has no continuous features, feature_weights is an
+        # empty array and the original `proximity_loss / sum(feature_weights)`
+        # divided by zero, raising RuntimeWarning + producing NaN losses that
+        # poison the genetic search. Proximity is conceptually undefined in
+        # that case (there are no continuous distances to weigh), so return a
+        # zero loss vector matching the population shape — see issue #276.
+        if len(feature_weights) == 0:
+            return np.zeros(x_hat.shape[0])
         product = np.multiply(
             (abs(x_hat - query_instance_normalized)[:, [self.data_interface.continuous_feature_indexes]]),
             feature_weights)

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -261,3 +261,64 @@ class TestDiceGeneticRegressionMethods:
         for cfs_example in ans.cf_examples_list:
             for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
                 assert desired_range[0] <= i <= desired_range[1]
+
+
+class TestComputeProximityLossNoContinuousFeatures:
+    """Regression for issue #276.
+
+    `DiceGenetic.compute_proximity_loss` divides by `sum(feature_weights)`,
+    where `feature_weights` is restricted to *continuous* feature indexes.
+    For an all-categorical dataset the array is empty and the original
+    implementation hit RuntimeWarning + NaN losses (or ZeroDivisionError on
+    older numpy). The genetic search then propagated NaN through `compute_loss`
+    and produced unusable counterfactuals.
+    """
+
+    def _make_explainer_categorical_only(self):
+        import numpy as np
+        import pandas as pd
+        from sklearn.compose import ColumnTransformer
+        from sklearn.pipeline import Pipeline
+        from sklearn.preprocessing import OneHotEncoder
+        from sklearn.linear_model import LogisticRegression
+
+        rng = np.random.default_rng(0)
+        df = pd.DataFrame({
+            "color": rng.choice(["red", "green", "blue"], size=60),
+            "shape": rng.choice(["circle", "square"], size=60),
+            "label": rng.integers(0, 2, size=60),
+        })
+        cat = ["color", "shape"]
+        X = df[cat]
+        y = df["label"]
+        clf = Pipeline([
+            ("ohe", ColumnTransformer([("o", OneHotEncoder(), cat)])),
+            ("lr", LogisticRegression(max_iter=200)),
+        ]).fit(X, y)
+
+        d = dice_ml.Data(dataframe=df, continuous_features=[],
+                         categorical_features=cat, outcome_name="label")
+        m = dice_ml.Model(model=clf, backend="sklearn")
+        return dice_ml.Dice(d, m, method="genetic")
+
+    def test_compute_proximity_loss_returns_zero_when_no_continuous_features(self):
+        import numpy as np
+        exp = self._make_explainer_categorical_only()
+        # Mirror the setup the explainer would normally do before any
+        # call to compute_proximity_loss: set continuous_feature_indexes
+        # (empty here) and populate feature_weights_list. Driving the full
+        # generate_counterfactuals path would exercise many other
+        # categorical-only code paths that aren't this bug.
+        exp.data_interface.continuous_feature_indexes = []
+        exp.feature_weights_list = [np.ones(len(exp.data_interface.feature_names))]
+        n_features = len(exp.data_interface.feature_names)
+        # normalize_data() consumes a 2-D ndarray for non-DataFrame input.
+        x_hat = np.zeros((4, n_features), dtype=float)
+        query = np.zeros((1, n_features), dtype=float)
+        # Must not raise / warn / produce NaN — origin/main produced
+        # RuntimeWarning: invalid value encountered in scalar divide
+        # plus NaN losses (or ZeroDivisionError on older numpy).
+        loss = exp.compute_proximity_loss(x_hat, query)
+        assert loss.shape == (4,)
+        assert np.all(loss == 0.0)
+        assert not np.any(np.isnan(loss))


### PR DESCRIPTION
## Summary

`DiceGenetic.compute_proximity_loss` divides by `sum(feature_weights)`,
where `feature_weights` is restricted to the **continuous** feature indexes.
For an all-categorical dataset (e.g. survey responses, OHE-only inputs)
that array is empty — and the original code hit either of two bugs
depending on input shape:

* `proximity_loss / sum(feature_weights)` ⇒ ZeroDivisionError /
  RuntimeWarning + NaN (the snippet @kburchfiel quoted in #276), or
* `product.reshape(-1, product.shape[-1])` ⇒ ValueError on the 0-sized
  array.

Both poison `compute_loss` with NaN/exceptions and break genetic search
for legitimate categorical-only use.

## Why

Proximity is conceptually undefined when there are no continuous distances
to weigh, so the function short-circuits with a zero loss vector matching
the population shape. The `categorical_penalty` term in `compute_loss`
already handles categorical sparsity, so dropping the proximity
contribution is the correct semantic — and matches what users expect when
they explicitly set up a categorical-only `dice_ml.Data`.

The change is one early-return on `len(feature_weights) == 0`. Comment in
the code explains the choice for future reviewers.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
set -e
cd /tmp && rm -rf DiCE-276 && git clone https://github.com/interpretml/DiCE.git DiCE-276
cd DiCE-276
pip install -q -e . pytest scikit-learn

git fetch https://github.com/jbbqqf/DiCE.git fix/276-proximity-loss-no-continuous
git checkout FETCH_HEAD -- tests/test_dice_interface/test_dice_genetic.py

# --- BEFORE: production code from origin/main ---
git checkout origin/main -- dice_ml/explainer_interfaces/dice_genetic.py
python -m pytest \"tests/test_dice_interface/test_dice_genetic.py::TestComputeProximityLossNoContinuousFeatures::test_compute_proximity_loss_returns_zero_when_no_continuous_features\" -q || echo \"BEFORE: ValueError 'cannot reshape array of size 0' (expected)\"

# --- AFTER: fix applied ---
git checkout FETCH_HEAD -- dice_ml/explainer_interfaces/dice_genetic.py
python -m pytest \"tests/test_dice_interface/test_dice_genetic.py::TestComputeProximityLossNoContinuousFeatures::test_compute_proximity_loss_returns_zero_when_no_continuous_features\" -q
# Expected: 1 passed
```

## What I ran locally

- New test passes on this branch
- Test fails on `origin/main` with `ValueError: cannot reshape array of size 0 into shape (0)` (the original snippet's `proximity_loss / sum(...)` path is reached only with a slightly different input shape, but both have the same root cause)
- Full `tests/test_dice_interface/test_dice_genetic.py` ran: same 4 pre-existing failures as `origin/main` (regression suite for `TestDiceGeneticRegressionMethods` is broken on main for separate reasons), 0 new failures introduced

## Edge cases

| dataset shape | path taken | result |
|---|---|---|
| Mixed continuous + categorical | unchanged | unchanged |
| All categorical (this fix) | new early-return | `np.zeros(population)` |
| All continuous | unchanged | unchanged |
| `proximity_weight = 0` | already short-circuited in `compute_loss` | unchanged |

## AI disclosure

This change was prepared with the assistance of Claude (Anthropic).
The author reviewed every line and is responsible for the final result.