### PR TITLE
Fix DiceGenetic.mate continuous-mutation typo pinning to lower bound (#441)

### DIFF
--- a/dice_ml/explainer_interfaces/dice_genetic.py
+++ b/dice_ml/explainer_interfaces/dice_genetic.py
@@ -419,8 +419,14 @@ class DiceGenetic(ExplainerBase):
                 # otherwise insert random gene(mutate) for maintaining diversity
                 if feat_name in features_to_vary:
                     if feat_name in self.data_interface.continuous_feature_names:
+                        # Mutate uniformly across the feature's [low, high] range.
+                        # The historical line passed feature_range[feat_name][0]
+                        # twice, which collapsed every continuous mutation to the
+                        # lower bound and starved the search of diversity — see
+                        # the do_random_init pattern at the top of this file
+                        # (`np.random.uniform(low, high)`) for the correct shape.
                         one_init[j] = np.random.uniform(self.feature_range[feat_name][0],
-                                                        self.feature_range[feat_name][0])
+                                                        self.feature_range[feat_name][1])
                     else:
                         one_init[j] = np.random.choice(self.feature_range[feat_name])
                 else:

--- a/tests/test_dice_interface/test_dice_genetic.py
+++ b/tests/test_dice_interface/test_dice_genetic.py
@@ -261,3 +261,66 @@ class TestDiceGeneticRegressionMethods:
         for cfs_example in ans.cf_examples_list:
             for i in cfs_example.final_cfs_df[self.exp.data_interface.outcome_name].values:
                 assert desired_range[0] <= i <= desired_range[1]
+
+
+class TestMateContinuousMutation:
+    """Regression for the typo behind a class of #441 / #260 reports.
+
+    `DiceGenetic.mate` mutates a continuous feature with
+    `np.random.uniform(low, high)`. The historical code passed
+    `feature_range[feat_name][0]` for both arguments, which collapses
+    every continuous mutation to the lower bound. That starves the
+    genetic search of diversity along continuous axes and is consistent
+    with users reporting that the genetic explainer ignores their
+    feature_range / features_to_vary intent on continuous features.
+    """
+
+    def test_mate_mutation_can_reach_upper_half_of_range(self):
+        import random
+        import types
+
+        import numpy as np
+
+        from dice_ml.explainer_interfaces.dice_genetic import DiceGenetic
+
+        # We don't need the full DiceGenetic init — only the `mate` method's
+        # dependencies. Build a minimal stand-in to keep this test fast and
+        # decoupled from data fixtures.
+        exp = DiceGenetic.__new__(DiceGenetic)
+        exp.data_interface = types.SimpleNamespace(
+            number_of_features=1,
+            feature_names=["x"],
+            continuous_feature_names=["x"],
+        )
+        exp.feature_range = {"x": [0.0, 100.0]}
+
+        # Force `mate` into the mutation branch (prob >= 0.80) deterministically
+        # by monkeypatching random.random within this test scope.
+        original_random = random.random
+        random.random = lambda: 0.99
+        try:
+            np.random.seed(0)
+            samples = []
+            for _ in range(200):
+                child = exp.mate(
+                    k1=np.array([0.0]),
+                    k2=np.array([0.0]),
+                    features_to_vary=["x"],
+                    query_instance=[0.0],
+                )
+                samples.append(child[0])
+        finally:
+            random.random = original_random
+
+        samples = np.array(samples)
+        # Every value must lie inside the declared feature range.
+        assert samples.min() >= 0.0
+        assert samples.max() <= 100.0
+        # The fix produces values across the range; the historical typo
+        # pinned every mutation to feature_range[name][0] (~0.0). We assert
+        # at least one mutation lands in the upper half of the range —
+        # essentially impossible on the broken code, near-certain after the fix.
+        assert (samples > 50.0).any(), (
+            "Continuous mutations are still pinned to the lower bound — "
+            "regression of the np.random.uniform(low, low) typo."
+        )


### PR DESCRIPTION
## Summary

`DiceGenetic.mate()` mutates a continuous feature with
`np.random.uniform(low, high)`, but the call passed
`feature_range[feat_name][0]` for **both** arguments. As a result every
continuous mutation collapsed to the lower bound of the feature's
declared range, leaving the genetic search to explore continuous axes
only via the parent-gene branches (prob < 0.80). Half of the
diversity-injection strategy was a no-op.

The two adjacent `np.random.uniform` calls in the same file
(`do_random_init` at line ~92 and `do_KD_init` at line ~124) both
correctly pass `low, high`, so this is a clear typo rather than an
intentional design choice — and it matches several user reports that
the genetic explainer \"ignores\" the user's `permitted_range` /
`features_to_vary` intent on continuous columns (see #441 and #260
comment threads).

## Why

One-character typo fix in the `else:` mutation branch of
`DiceGenetic.mate`. Restores the documented diversity behaviour of the
genetic algorithm.

I left a 4-line comment at the call site explaining the prior bug —
without it, a future reviewer or refactor could easily re-introduce
the same typo in another mutation path.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
set -e
cd /tmp && rm -rf DiCE-441 && git clone https://github.com/interpretml/DiCE.git DiCE-441
cd DiCE-441
pip install -q -e . pytest

git fetch https://github.com/jbbqqf/DiCE.git fix/441-genetic-mate-uniform-typo
git checkout FETCH_HEAD -- tests/test_dice_interface/test_dice_genetic.py

# --- BEFORE: production code from origin/main ---
git checkout origin/main -- dice_ml/explainer_interfaces/dice_genetic.py
python -m pytest tests/test_dice_interface/test_dice_genetic.py::TestMateContinuousMutation -q || echo \"BEFORE: AssertionError 'pinned to the lower bound' (expected)\"
# Expected: 1 failed — 'samples > 50.0' is False because every mutation collapsed to feature_range[name][0]

# --- AFTER: fix applied ---
git checkout FETCH_HEAD -- dice_ml/explainer_interfaces/dice_genetic.py
python -m pytest tests/test_dice_interface/test_dice_genetic.py::TestMateContinuousMutation -q
# Expected: 1 passed — mutations now spread across the declared [0, 100] range
```

## What I ran locally

- New test passes on this branch
- New test fails on `origin/main` with all 200 samples == 0.0 (every mutation pinned to the lower bound of the feature range, exactly as the typo dictates)
- Direct line-by-line diff with adjacent `np.random.uniform(low, high)` call sites confirms the fix matches the established pattern in this file

## Edge cases

| call site | feature_range | mutation distribution |
|---|---|---|
| BEFORE: continuous mutation in `mate` | `[0, 100]` | all samples collapsed to 0.0 |
| AFTER: continuous mutation in `mate` | `[0, 100]` | uniform over [0, 100] |
| Categorical mutation in `mate` | unchanged — uses `np.random.choice` | unchanged |
| Continuous mutation in `do_random_init` | already correct (`low, high`) | unchanged |
| Continuous mutation in `do_KD_init` | already correct (`low, high`) | unchanged |

## AI disclosure

This change was prepared with the assistance of Claude (Anthropic).
The author reviewed every line and is responsible for the final result.